### PR TITLE
예외 케이스 덮어쓰지 못하도록 summary, description 제거

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,7 +1,7 @@
 name: Backend Dev CD
 
 on:
-  pull_request:
+  push:
     branches: [ main ]
 
 jobs:

--- a/src/test/java/com/example/demo/infrastructure/controller/LedgerDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/LedgerDocumentationTest.java
@@ -940,7 +940,7 @@ class LedgerDocumentationTest {
                         )
                         .responseSchema(Schema.schema("ErrorResponse"))
                         .responseFields(
-                            fieldWithPath("message").type(STRING).description("요청 파라미터 형식이 올바르지 않습니다 : start"),
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
                             fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
                         )
                         .build())


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 작업 요약을 한 줄로 적어주세요")

## 이슈
- Close #40 

## 요약
- summary, description을 예외 케이스에도 쓰면 가끔 얘가 덮어씌우더라고요.
  - 그래서 그냥 document 내에 설명하는 방식으로 변경했습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 문서화를 개선하여 오류 및 엣지 케이스 시나리오에 대한 설명을 추가했습니다.
  * 토큰 및 사용자 관련 실패 케이스 문서를 보다 명확하게 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->