### PR TITLE
친구 기능 구현

### DIFF
--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -1,6 +1,7 @@
 package com.example.demo.application;
 
 import com.example.demo.application.dto.MateInfo;
+import com.example.demo.application.dto.MateReceivedInfo;
 import com.example.demo.domain.Mate;
 import com.example.demo.domain.MateRepository;
 import com.example.demo.domain.User;
@@ -38,6 +39,17 @@ public class MateService {
                         result.mate().getId(),
                         result.friend().getNickname(),
                         result.friend().getInvitationCode().value()
+                ))
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MateReceivedInfo> getReceivedRequests(Long userId) {
+        return mateRepository.findAllPendingByReceiverId(userId).stream()
+                .map(mate -> new MateReceivedInfo(
+                        mate.getId(),
+                        mate.getRequester().getNickname(),
+                        mate.getRequester().getInvitationCode().value()
                 ))
                 .toList();
     }

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -54,11 +54,11 @@ public class MateService {
             throw new IllegalArgumentException("친구 요청의 수신자만 수락/거절할 수 있습니다.");
         }
 
-        if (status == MateStatus.ACCEPTED) {
-            mate.accept();
-            return;
+        switch (status) {
+            case ACCEPTED -> mate.accept();
+            case REJECTED -> mate.reject();
+            default -> throw new IllegalArgumentException("친구요청은 수락 또는 거절로만 변경 가능합니다.");
         }
-        mate.reject();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -6,6 +6,7 @@ import com.example.demo.domain.Mate;
 import com.example.demo.domain.MateRepository;
 import com.example.demo.domain.User;
 import com.example.demo.domain.UserRepository;
+import com.example.demo.domain.enums.MateStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,9 +22,9 @@ public class MateService {
     @Transactional
     public Long requestMate(Long userId, String invitationCode) {
         User requester = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         User receiver = userRepository.findByInvitationCode_Value(invitationCode)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 초대코드입니다."));
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 초대코드입니다."));
 
         if (mateRepository.existsMateBetween(requester.getId(), receiver.getId())) {
             throw new IllegalArgumentException("이미 친구 관계가 존재하거나 요청 대기 중입니다.");
@@ -35,22 +36,38 @@ public class MateService {
     @Transactional(readOnly = true)
     public List<MateInfo> getAcceptedMates(Long userId) {
         return mateRepository.findAllAcceptedWithFriend(userId).stream()
-                .map(result -> new MateInfo(
-                        result.mate().getId(),
-                        result.friend().getNickname(),
-                        result.friend().getInvitationCode().value()
-                ))
-                .toList();
+            .map(result -> new MateInfo(
+                result.mate().getId(),
+                result.friend().getNickname(),
+                result.friend().getInvitationCode().value()
+            ))
+            .toList();
+    }
+
+    @Transactional
+    public void updateMateStatus(Long mateId, Long userId, MateStatus status) {
+        Mate mate = mateRepository.findById(mateId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 친구 요청입니다."));
+
+        if (!mate.getReceiver().getId().equals(userId)) {
+            throw new IllegalArgumentException("친구 요청의 수신자만 수락/거절할 수 있습니다.");
+        }
+
+        if (status == MateStatus.ACCEPTED) {
+            mate.accept();
+            return;
+        }
+        mate.reject();
     }
 
     @Transactional(readOnly = true)
     public List<MateReceivedInfo> getReceivedRequests(Long userId) {
         return mateRepository.findAllPendingByReceiverId(userId).stream()
-                .map(mate -> new MateReceivedInfo(
-                        mate.getId(),
-                        mate.getRequester().getNickname(),
-                        mate.getRequester().getInvitationCode().value()
-                ))
-                .toList();
+            .map(mate -> new MateReceivedInfo(
+                mate.getId(),
+                mate.getRequester().getNickname(),
+                mate.getRequester().getInvitationCode().value()
+            ))
+            .toList();
     }
 }

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -39,7 +39,8 @@ public class MateService {
             .map(result -> new MateInfo(
                 result.mate().getId(),
                 result.friend().getNickname(),
-                result.friend().getInvitationCode().value()
+                result.friend().getInvitationCode().value(),
+                0 // TODO: 함께한 심판 횟수를 조회하여 반환
             ))
             .toList();
     }

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -1,9 +1,11 @@
 package com.example.demo.application;
 
+import com.example.demo.application.dto.MateInfo;
 import com.example.demo.domain.Mate;
 import com.example.demo.domain.MateRepository;
 import com.example.demo.domain.User;
 import com.example.demo.domain.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +29,16 @@ public class MateService {
         }
 
         return mateRepository.save(new Mate(requester, receiver)).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MateInfo> getAcceptedMates(Long userId) {
+        return mateRepository.findAllAcceptedWithFriend(userId).stream()
+                .map(result -> new MateInfo(
+                        result.mate().getId(),
+                        result.friend().getNickname(),
+                        result.friend().getInvitationCode().value()
+                ))
+                .toList();
     }
 }

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -1,0 +1,31 @@
+package com.example.demo.application;
+
+import com.example.demo.domain.Mate;
+import com.example.demo.domain.MateRepository;
+import com.example.demo.domain.User;
+import com.example.demo.domain.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MateService {
+
+    private final MateRepository mateRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long requestMate(Long userId, String invitationCode) {
+        User requester = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        User receiver = userRepository.findByInvitationCode_Value(invitationCode)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 초대코드입니다."));
+
+        if (mateRepository.existsMateBetween(requester.getId(), receiver.getId())) {
+            throw new IllegalArgumentException("이미 친구 관계가 존재하거나 요청 대기 중입니다.");
+        }
+
+        return mateRepository.save(new Mate(requester, receiver)).getId();
+    }
+}

--- a/src/main/java/com/example/demo/application/dto/MateInfo.java
+++ b/src/main/java/com/example/demo/application/dto/MateInfo.java
@@ -1,0 +1,4 @@
+package com.example.demo.application.dto;
+
+public record MateInfo(Long mateId, String nickname, String invitationCode) {
+}

--- a/src/main/java/com/example/demo/application/dto/MateInfo.java
+++ b/src/main/java/com/example/demo/application/dto/MateInfo.java
@@ -1,4 +1,4 @@
 package com.example.demo.application.dto;
 
-public record MateInfo(Long mateId, String nickname, String invitationCode) {
+public record MateInfo(Long mateId, String nickname, String invitationCode, int verdictCount) {
 }

--- a/src/main/java/com/example/demo/application/dto/MateReceivedInfo.java
+++ b/src/main/java/com/example/demo/application/dto/MateReceivedInfo.java
@@ -1,0 +1,4 @@
+package com.example.demo.application.dto;
+
+public record MateReceivedInfo(Long mateId, String nickname, String invitationCode) {
+}

--- a/src/main/java/com/example/demo/domain/Mate.java
+++ b/src/main/java/com/example/demo/domain/Mate.java
@@ -68,11 +68,4 @@ public class Mate extends BaseEntity {
         }
         this.status = MateStatus.REJECTED;
     }
-
-    public User getFriend(Long myUserId) {
-        if (this.requester.getId().equals(myUserId)) {
-            return this.receiver;
-        }
-        return this.requester;
-    }
 }

--- a/src/main/java/com/example/demo/domain/Mate.java
+++ b/src/main/java/com/example/demo/domain/Mate.java
@@ -1,0 +1,78 @@
+package com.example.demo.domain;
+
+import com.example.demo.domain.enums.MateStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mate extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "requester_id", nullable = false)
+    private User requester;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "receiver_id", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MateStatus status;
+
+    private LocalDateTime acceptedAt;
+
+    public Mate(User requester, User receiver) {
+        if (requester == null) {
+            throw new IllegalArgumentException("요청자는 필수입니다.");
+        }
+        if (receiver == null) {
+            throw new IllegalArgumentException("수신자는 필수입니다.");
+        }
+        if (requester.getId().equals(receiver.getId())) {
+            throw new IllegalArgumentException("자기 자신에게 친구 요청을 보낼 수 없습니다.");
+        }
+        this.requester = requester;
+        this.receiver = receiver;
+        this.status = MateStatus.PENDING;
+    }
+
+    public void accept() {
+        if (this.status != MateStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 요청만 수락할 수 있습니다.");
+        }
+        this.status = MateStatus.ACCEPTED;
+        this.acceptedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        if (this.status != MateStatus.PENDING) {
+            throw new IllegalArgumentException("대기 중인 요청만 거절할 수 있습니다.");
+        }
+        this.status = MateStatus.REJECTED;
+    }
+
+    public User getFriend(Long myUserId) {
+        if (this.requester.getId().equals(myUserId)) {
+            return this.receiver;
+        }
+        return this.requester;
+    }
+}

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -1,0 +1,19 @@
+package com.example.demo.domain;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface MateRepository extends Repository<Mate, Long> {
+
+    Mate save(Mate mate);
+
+    Optional<Mate> findById(Long id);
+
+    @Query("SELECT COUNT(m) > 0 FROM Mate m " +
+            "WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id) " +
+            "OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id)) " +
+            "AND m.status IN ('PENDING', 'ACCEPTED')")
+    boolean existsMateBetween(@Param("user1Id") Long user1Id, @Param("user2Id") Long user2Id);
+}

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -1,5 +1,6 @@
 package com.example.demo.domain;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -16,4 +17,11 @@ public interface MateRepository extends Repository<Mate, Long> {
             "OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id)) " +
             "AND m.status IN ('PENDING', 'ACCEPTED')")
     boolean existsMateBetween(@Param("user1Id") Long user1Id, @Param("user2Id") Long user2Id);
+
+    @Query("SELECT new com.example.demo.domain.MateWithFriend(m, f) " +
+            "FROM Mate m " +
+            "JOIN User f ON (m.requester.id = :userId AND f.id = m.receiver.id) " +
+            "            OR (m.receiver.id = :userId AND f.id = m.requester.id) " +
+            "WHERE m.status = 'ACCEPTED'")
+    List<MateWithFriend> findAllAcceptedWithFriend(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -24,4 +24,8 @@ public interface MateRepository extends Repository<Mate, Long> {
             "            OR (m.receiver.id = :userId AND f.id = m.requester.id) " +
             "WHERE m.status = 'ACCEPTED'")
     List<MateWithFriend> findAllAcceptedWithFriend(@Param("userId") Long userId);
+
+    @Query("SELECT m FROM Mate m JOIN FETCH m.requester " +
+            "WHERE m.receiver.id = :userId AND m.status = 'PENDING'")
+    List<Mate> findAllPendingByReceiverId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -13,19 +13,20 @@ public interface MateRepository extends Repository<Mate, Long> {
     Optional<Mate> findById(Long id);
 
     @Query("SELECT COUNT(m) > 0 FROM Mate m " +
-            "WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id) " +
-            "OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id)) " +
-            "AND m.status IN ('PENDING', 'ACCEPTED')")
+        "WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id) " +
+        "OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id)) " +
+        "AND m.status IN ('PENDING', 'ACCEPTED')")
     boolean existsMateBetween(@Param("user1Id") Long user1Id, @Param("user2Id") Long user2Id);
 
     @Query("SELECT new com.example.demo.domain.MateWithFriend(m, f) " +
-            "FROM Mate m " +
-            "JOIN User f ON (m.requester.id = :userId AND f.id = m.receiver.id) " +
-            "            OR (m.receiver.id = :userId AND f.id = m.requester.id) " +
-            "WHERE m.status = 'ACCEPTED'")
+        "FROM Mate m " +
+        "JOIN User f ON (m.requester.id = :userId AND f.id = m.receiver.id) " +
+        "            OR (m.receiver.id = :userId AND f.id = m.requester.id) " +
+        "WHERE m.status = 'ACCEPTED' " +
+        "AND (m.requester.id = :userId OR m.receiver.id = :userId)")
     List<MateWithFriend> findAllAcceptedWithFriend(@Param("userId") Long userId);
 
     @Query("SELECT m FROM Mate m JOIN FETCH m.requester " +
-            "WHERE m.receiver.id = :userId AND m.status = 'PENDING'")
+        "WHERE m.receiver.id = :userId AND m.status = 'PENDING'")
     List<Mate> findAllPendingByReceiverId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/demo/domain/MateWithFriend.java
+++ b/src/main/java/com/example/demo/domain/MateWithFriend.java
@@ -1,0 +1,7 @@
+package com.example.demo.domain;
+
+public record MateWithFriend(
+        Mate mate,
+        User friend
+) {
+}

--- a/src/main/java/com/example/demo/domain/UserRepository.java
+++ b/src/main/java/com/example/demo/domain/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends Repository<User, Long> {
     void deleteById(Long userId);
 
     boolean existsByNickname_Value(String nickname);
+
+    Optional<User> findByInvitationCode_Value(String code);
 }

--- a/src/main/java/com/example/demo/domain/enums/MateStatus.java
+++ b/src/main/java/com/example/demo/domain/enums/MateStatus.java
@@ -1,0 +1,5 @@
+package com.example.demo.domain.enums;
+
+public enum MateStatus {
+    PENDING, ACCEPTED, REJECTED
+}

--- a/src/main/java/com/example/demo/domain/enums/MateStatus.java
+++ b/src/main/java/com/example/demo/domain/enums/MateStatus.java
@@ -1,5 +1,9 @@
 package com.example.demo.domain.enums;
 
 public enum MateStatus {
-    PENDING, ACCEPTED, REJECTED
+    PENDING, ACCEPTED, REJECTED;
+
+    public boolean isPending() {
+        return this == PENDING;
+    }
 }

--- a/src/main/java/com/example/demo/domain/enums/MateVerdictStatus.java
+++ b/src/main/java/com/example/demo/domain/enums/MateVerdictStatus.java
@@ -1,0 +1,5 @@
+package com.example.demo.domain.enums;
+
+public enum MateVerdictStatus {
+    ACCEPTED, REJECTED
+}

--- a/src/main/java/com/example/demo/domain/enums/MateVerdictStatus.java
+++ b/src/main/java/com/example/demo/domain/enums/MateVerdictStatus.java
@@ -1,5 +1,0 @@
-package com.example.demo.domain.enums;
-
-public enum MateVerdictStatus {
-    ACCEPTED, REJECTED
-}

--- a/src/main/java/com/example/demo/infrastructure/controller/MateController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/MateController.java
@@ -5,6 +5,7 @@ import com.example.demo.infrastructure.controller.dto.CreateMateWebRequest;
 import com.example.demo.infrastructure.controller.dto.MateCreateWebResponse;
 import com.example.demo.infrastructure.controller.dto.MateInfoWebResponse;
 import com.example.demo.infrastructure.controller.dto.MateReceivedWebResponse;
+import com.example.demo.infrastructure.controller.dto.UpdateMateStatusWebRequest;
 import com.example.demo.infrastructure.interceptor.UserId;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -12,6 +13,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,5 +51,15 @@ public class MateController {
                         .map(MateReceivedWebResponse::from)
                         .toList()
         );
+    }
+
+    @PatchMapping("/mates/{mateId}")
+    public ResponseEntity<Void> updateMateStatus(
+            @UserId Long userId,
+            @PathVariable Long mateId,
+            @Valid @RequestBody UpdateMateStatusWebRequest request
+    ) {
+        mateService.updateMateStatus(mateId, userId, request.status());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/MateController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/MateController.java
@@ -4,6 +4,7 @@ import com.example.demo.application.MateService;
 import com.example.demo.infrastructure.controller.dto.CreateMateWebRequest;
 import com.example.demo.infrastructure.controller.dto.MateCreateWebResponse;
 import com.example.demo.infrastructure.controller.dto.MateInfoWebResponse;
+import com.example.demo.infrastructure.controller.dto.MateReceivedWebResponse;
 import com.example.demo.infrastructure.interceptor.UserId;
 import jakarta.validation.Valid;
 import java.net.URI;
@@ -36,6 +37,15 @@ public class MateController {
         return ResponseEntity.ok(
                 mateService.getAcceptedMates(userId).stream()
                         .map(MateInfoWebResponse::from)
+                        .toList()
+        );
+    }
+
+    @GetMapping("/mates/received")
+    public ResponseEntity<List<MateReceivedWebResponse>> getReceivedRequests(@UserId Long userId) {
+        return ResponseEntity.ok(
+                mateService.getReceivedRequests(userId).stream()
+                        .map(MateReceivedWebResponse::from)
                         .toList()
         );
     }

--- a/src/main/java/com/example/demo/infrastructure/controller/MateController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/MateController.java
@@ -3,11 +3,14 @@ package com.example.demo.infrastructure.controller;
 import com.example.demo.application.MateService;
 import com.example.demo.infrastructure.controller.dto.CreateMateWebRequest;
 import com.example.demo.infrastructure.controller.dto.MateCreateWebResponse;
+import com.example.demo.infrastructure.controller.dto.MateInfoWebResponse;
 import com.example.demo.infrastructure.interceptor.UserId;
 import jakarta.validation.Valid;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +29,14 @@ public class MateController {
         Long mateId = mateService.requestMate(userId, request.invitationCode());
         URI location = URI.create("/mates/" + mateId);
         return ResponseEntity.created(location).body(new MateCreateWebResponse(mateId));
+    }
+
+    @GetMapping("/mates")
+    public ResponseEntity<List<MateInfoWebResponse>> getAcceptedMates(@UserId Long userId) {
+        return ResponseEntity.ok(
+                mateService.getAcceptedMates(userId).stream()
+                        .map(MateInfoWebResponse::from)
+                        .toList()
+        );
     }
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/MateController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/MateController.java
@@ -27,8 +27,8 @@ public class MateController {
 
     @PostMapping("/mates")
     public ResponseEntity<MateCreateWebResponse> create(
-            @UserId Long userId,
-            @Valid @RequestBody CreateMateWebRequest request
+        @UserId Long userId,
+        @Valid @RequestBody CreateMateWebRequest request
     ) {
         Long mateId = mateService.requestMate(userId, request.invitationCode());
         URI location = URI.create("/mates/" + mateId);
@@ -38,27 +38,30 @@ public class MateController {
     @GetMapping("/mates")
     public ResponseEntity<List<MateInfoWebResponse>> getAcceptedMates(@UserId Long userId) {
         return ResponseEntity.ok(
-                mateService.getAcceptedMates(userId).stream()
-                        .map(MateInfoWebResponse::from)
-                        .toList()
+            mateService.getAcceptedMates(userId).stream()
+                .map(MateInfoWebResponse::from)
+                .toList()
         );
     }
 
     @GetMapping("/mates/received")
     public ResponseEntity<List<MateReceivedWebResponse>> getReceivedRequests(@UserId Long userId) {
         return ResponseEntity.ok(
-                mateService.getReceivedRequests(userId).stream()
-                        .map(MateReceivedWebResponse::from)
-                        .toList()
+            mateService.getReceivedRequests(userId).stream()
+                .map(MateReceivedWebResponse::from)
+                .toList()
         );
     }
 
     @PatchMapping("/mates/{mateId}")
     public ResponseEntity<Void> updateMateStatus(
-            @UserId Long userId,
-            @PathVariable Long mateId,
-            @Valid @RequestBody UpdateMateStatusWebRequest request
+        @UserId Long userId,
+        @PathVariable Long mateId,
+        @Valid @RequestBody UpdateMateStatusWebRequest request
     ) {
+        if (request.status().isPending()) {
+            throw new IllegalArgumentException("친구요청은 수락 또는 거절로만 변경 가능합니다.");
+        }
         mateService.updateMateStatus(mateId, userId, request.status());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/example/demo/infrastructure/controller/MateController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/MateController.java
@@ -59,9 +59,6 @@ public class MateController {
         @PathVariable Long mateId,
         @Valid @RequestBody UpdateMateStatusWebRequest request
     ) {
-        if (request.status().isPending()) {
-            throw new IllegalArgumentException("친구요청은 수락 또는 거절로만 변경 가능합니다.");
-        }
         mateService.updateMateStatus(mateId, userId, request.status());
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/example/demo/infrastructure/controller/MateController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/MateController.java
@@ -1,0 +1,30 @@
+package com.example.demo.infrastructure.controller;
+
+import com.example.demo.application.MateService;
+import com.example.demo.infrastructure.controller.dto.CreateMateWebRequest;
+import com.example.demo.infrastructure.controller.dto.MateCreateWebResponse;
+import com.example.demo.infrastructure.interceptor.UserId;
+import jakarta.validation.Valid;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MateController {
+
+    private final MateService mateService;
+
+    @PostMapping("/mates")
+    public ResponseEntity<MateCreateWebResponse> create(
+            @UserId Long userId,
+            @Valid @RequestBody CreateMateWebRequest request
+    ) {
+        Long mateId = mateService.requestMate(userId, request.invitationCode());
+        URI location = URI.create("/mates/" + mateId);
+        return ResponseEntity.created(location).body(new MateCreateWebResponse(mateId));
+    }
+}

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/CreateMateWebRequest.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/CreateMateWebRequest.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record CreateMateWebRequest(
-        @NotBlank
-        @Pattern(regexp = "^[A-Z]{6}$", message = "올바르지 않은 초대 코드 형식입니다 (영어 대문자 6자리)")
-        String invitationCode
+    @NotBlank
+    @Pattern(regexp = "^[A-Z]{6}$", message = "올바르지 않은 초대 코드 형식입니다 (영어 대문자 6자리)")
+    String invitationCode
 ) {
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/CreateMateWebRequest.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/CreateMateWebRequest.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record CreateMateWebRequest(
-        @NotBlank @Pattern(regexp = "^[A-Z]{6}$") String invitationCode
+        @NotBlank
+        @Pattern(regexp = "^[A-Z]{6}$", message = "올바르지 않은 초대 코드 형식입니다 (영어 대문자 6자리)")
+        String invitationCode
 ) {
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/CreateMateWebRequest.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/CreateMateWebRequest.java
@@ -1,0 +1,9 @@
+package com.example.demo.infrastructure.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CreateMateWebRequest(
+        @NotBlank @Pattern(regexp = "^[A-Z]{6}$") String invitationCode
+) {
+}

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/MateCreateWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/MateCreateWebResponse.java
@@ -1,0 +1,4 @@
+package com.example.demo.infrastructure.controller.dto;
+
+public record MateCreateWebResponse(Long mateId) {
+}

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/MateInfoWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/MateInfoWebResponse.java
@@ -1,0 +1,10 @@
+package com.example.demo.infrastructure.controller.dto;
+
+import com.example.demo.application.dto.MateInfo;
+
+public record MateInfoWebResponse(Long mateId, String nickname, String invitationCode) {
+
+    public static MateInfoWebResponse from(MateInfo info) {
+        return new MateInfoWebResponse(info.mateId(), info.nickname(), info.invitationCode());
+    }
+}

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/MateInfoWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/MateInfoWebResponse.java
@@ -2,9 +2,9 @@ package com.example.demo.infrastructure.controller.dto;
 
 import com.example.demo.application.dto.MateInfo;
 
-public record MateInfoWebResponse(Long mateId, String nickname, String invitationCode) {
+public record MateInfoWebResponse(Long mateId, String nickname, String invitationCode, int verdictCount) {
 
     public static MateInfoWebResponse from(MateInfo info) {
-        return new MateInfoWebResponse(info.mateId(), info.nickname(), info.invitationCode());
+        return new MateInfoWebResponse(info.mateId(), info.nickname(), info.invitationCode(), info.verdictCount());
     }
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/MateReceivedWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/MateReceivedWebResponse.java
@@ -1,0 +1,10 @@
+package com.example.demo.infrastructure.controller.dto;
+
+import com.example.demo.application.dto.MateReceivedInfo;
+
+public record MateReceivedWebResponse(Long mateId, String nickname, String invitationCode) {
+
+    public static MateReceivedWebResponse from(MateReceivedInfo info) {
+        return new MateReceivedWebResponse(info.mateId(), info.nickname(), info.invitationCode());
+    }
+}

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/UpdateMateStatusWebRequest.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/UpdateMateStatusWebRequest.java
@@ -1,0 +1,7 @@
+package com.example.demo.infrastructure.controller.dto;
+
+import com.example.demo.domain.enums.MateStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateMateStatusWebRequest(@NotNull MateStatus status) {
+}

--- a/src/test/java/com/example/demo/application/MateServiceTest.java
+++ b/src/test/java/com/example/demo/application/MateServiceTest.java
@@ -1,10 +1,7 @@
 package com.example.demo.application;
 
-import static com.example.demo.util.DbUtils.givenSavedUser;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.example.demo.application.dto.MateInfo;
+import com.example.demo.application.dto.MateReceivedInfo;
 import com.example.demo.domain.InvitationCode;
 import com.example.demo.domain.Mate;
 import com.example.demo.domain.MateRepository;
@@ -18,6 +15,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.example.demo.util.DbUtils.givenSavedUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MateServiceTest extends AbstractIntegrationTest {
 
@@ -125,7 +126,7 @@ class MateServiceTest extends AbstractIntegrationTest {
             // then
             assertThat(result).hasSize(2);
             assertThat(result).extracting(MateInfo::nickname)
-                    .containsExactlyInAnyOrder("친구1", "친구2");
+                .containsExactlyInAnyOrder("친구1", "친구2");
         }
 
         @Test
@@ -161,11 +162,69 @@ class MateServiceTest extends AbstractIntegrationTest {
             assertThat(result.get(0).nickname()).isEqualTo("요청자");
             assertThat(result.get(0).invitationCode()).isEqualTo("RRRRRR");
         }
+    }
 
-        private void acceptMate(Long mateId) {
-            Mate mate = mateRepository.findById(mateId).orElseThrow();
-            mate.accept();
-            mateRepository.save(mate);
+    @Nested
+    @DisplayName("받은 친구 요청 조회")
+    class GetReceivedRequests {
+
+        @Test
+        void PENDING_상태의_받은_요청만_반환된다() {
+            // given
+            User me = givenSavedUser(userRepository);
+            User sender1 = givenSavedUser(userRepository, new Nickname("보낸사람1"), new InvitationCode("AAAAAA"));
+            User sender2 = givenSavedUser(userRepository, new Nickname("보낸사람2"), new InvitationCode("BBBBBB"));
+            User sender3 = givenSavedUser(userRepository, new Nickname("수락됨"), new InvitationCode("CCCCCC"));
+
+            sut.requestMate(sender1.getId(), me.getInvitationCode().value()); // PENDING
+            sut.requestMate(sender2.getId(), me.getInvitationCode().value()); // PENDING
+            Long acceptedMateId = sut.requestMate(sender3.getId(), me.getInvitationCode().value());
+            acceptMate(acceptedMateId); // ACCEPTED
+
+            // when
+            var result = sut.getReceivedRequests(me.getId());
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(MateReceivedInfo::nickname)
+                .containsExactlyInAnyOrder("보낸사람1", "보낸사람2");
         }
+
+        @Test
+        void 내가_보낸_요청은_반환되지_않는다() {
+            // given
+            User me = givenSavedUser(userRepository);
+            User other = givenSavedUser(userRepository, new Nickname("상대방"), new InvitationCode("OOOOOO"));
+            sut.requestMate(me.getId(), "OOOOOO"); // 내가 보낸 요청
+
+            // when
+            var result = sut.getReceivedRequests(me.getId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void 요청자의_닉네임과_초대코드가_포함된다() {
+            // given
+            User me = givenSavedUser(userRepository);
+            User sender = givenSavedUser(userRepository, new Nickname("친구"), new InvitationCode("FFFFFF"));
+            sut.requestMate(sender.getId(), me.getInvitationCode().value());
+
+            // when
+            var result = sut.getReceivedRequests(me.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).nickname()).isEqualTo("친구");
+            assertThat(result.get(0).invitationCode()).isEqualTo("FFFFFF");
+            assertThat(result.get(0).mateId()).isNotNull();
+        }
+    }
+
+    private void acceptMate(Long mateId) {
+        Mate mate = mateRepository.findById(mateId).orElseThrow();
+        mate.accept();
+        mateRepository.save(mate);
     }
 }

--- a/src/test/java/com/example/demo/application/MateServiceTest.java
+++ b/src/test/java/com/example/demo/application/MateServiceTest.java
@@ -222,6 +222,81 @@ class MateServiceTest extends AbstractIntegrationTest {
         }
     }
 
+    @Nested
+    @DisplayName("친구 요청 수락/거절")
+    class UpdateMateStatus {
+
+        @Test
+        void 친구_요청을_수락하면_ACCEPTED_상태가_된다() {
+            // given
+            User requester = givenSavedUser(userRepository, new Nickname("요청자"), new InvitationCode("RRRRRR"));
+            User receiver = givenSavedUser(userRepository, new Nickname("수신자"), new InvitationCode("EEEEEE"));
+            Long mateId = sut.requestMate(requester.getId(), "EEEEEE");
+
+            // when
+            sut.updateMateStatus(mateId, receiver.getId(), MateStatus.ACCEPTED);
+
+            // then
+            Mate mate = mateRepository.findById(mateId).orElseThrow();
+            assertThat(mate.getStatus()).isEqualTo(MateStatus.ACCEPTED);
+            assertThat(mate.getAcceptedAt()).isNotNull();
+        }
+
+        @Test
+        void 친구_요청을_거절하면_REJECTED_상태가_된다() {
+            // given
+            User requester = givenSavedUser(userRepository, new Nickname("요청자"), new InvitationCode("RRRRRR"));
+            User receiver = givenSavedUser(userRepository, new Nickname("수신자"), new InvitationCode("EEEEEE"));
+            Long mateId = sut.requestMate(requester.getId(), "EEEEEE");
+
+            // when
+            sut.updateMateStatus(mateId, receiver.getId(), MateStatus.REJECTED);
+
+            // then
+            Mate mate = mateRepository.findById(mateId).orElseThrow();
+            assertThat(mate.getStatus()).isEqualTo(MateStatus.REJECTED);
+        }
+
+        @Test
+        void 존재하지_않는_Mate이면_예외가_발생한다() {
+            // given
+            User receiver = givenSavedUser(userRepository);
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateMateStatus(999L, receiver.getId(), MateStatus.ACCEPTED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 친구 요청입니다.");
+        }
+
+        @Test
+        void receiver가_아닌_사용자가_요청하면_예외가_발생한다() {
+            // given
+            User requester = givenSavedUser(userRepository, new Nickname("요청자"), new InvitationCode("RRRRRR"));
+            User receiver = givenSavedUser(userRepository, new Nickname("수신자"), new InvitationCode("EEEEEE"));
+            User other = givenSavedUser(userRepository, new Nickname("다른사람"), new InvitationCode("OOOOOO"));
+            Long mateId = sut.requestMate(requester.getId(), "EEEEEE");
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateMateStatus(mateId, other.getId(), MateStatus.ACCEPTED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("친구 요청의 수신자만 수락/거절할 수 있습니다.");
+        }
+
+        @Test
+        void 이미_처리된_요청이면_예외가_발생한다() {
+            // given
+            User requester = givenSavedUser(userRepository, new Nickname("요청자"), new InvitationCode("RRRRRR"));
+            User receiver = givenSavedUser(userRepository, new Nickname("수신자"), new InvitationCode("EEEEEE"));
+            Long mateId = sut.requestMate(requester.getId(), "EEEEEE");
+            sut.updateMateStatus(mateId, receiver.getId(), MateStatus.ACCEPTED);
+
+            // when & then
+            assertThatThrownBy(() -> sut.updateMateStatus(mateId, receiver.getId(), MateStatus.REJECTED))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("대기 중인 요청만 거절할 수 있습니다.");
+        }
+    }
+
     private void acceptMate(Long mateId) {
         Mate mate = mateRepository.findById(mateId).orElseThrow();
         mate.accept();

--- a/src/test/java/com/example/demo/application/MateServiceTest.java
+++ b/src/test/java/com/example/demo/application/MateServiceTest.java
@@ -4,13 +4,16 @@ import static com.example.demo.util.DbUtils.givenSavedUser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.example.demo.application.dto.MateInfo;
 import com.example.demo.domain.InvitationCode;
+import com.example.demo.domain.Mate;
 import com.example.demo.domain.MateRepository;
 import com.example.demo.domain.Nickname;
 import com.example.demo.domain.User;
 import com.example.demo.domain.UserRepository;
 import com.example.demo.domain.enums.MateStatus;
 import com.example.demo.util.AbstractIntegrationTest;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -94,6 +97,75 @@ class MateServiceTest extends AbstractIntegrationTest {
             assertThatThrownBy(() -> sut.requestMate(userA.getId(), "BBBBBB")) // A→B 요청
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("이미 친구 관계가 존재하거나 요청 대기 중입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 목록 조회")
+    class GetAcceptedMates {
+
+        @Test
+        void ACCEPTED_친구만_반환된다() {
+            // given
+            User me = givenSavedUser(userRepository);
+            User friend1 = givenSavedUser(userRepository, new Nickname("친구1"), new InvitationCode("FFAAAA"));
+            User friend2 = givenSavedUser(userRepository, new Nickname("친구2"), new InvitationCode("FFBBBB"));
+            User pending = givenSavedUser(userRepository, new Nickname("대기자"), new InvitationCode("PPPPPP"));
+
+            Long mateId1 = sut.requestMate(me.getId(), "FFAAAA");
+            Long mateId2 = sut.requestMate(me.getId(), "FFBBBB");
+            sut.requestMate(me.getId(), "PPPPPP"); // PENDING 상태 유지
+
+            acceptMate(mateId1);
+            acceptMate(mateId2);
+
+            // when
+            List<MateInfo> result = sut.getAcceptedMates(me.getId());
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(MateInfo::nickname)
+                    .containsExactlyInAnyOrder("친구1", "친구2");
+        }
+
+        @Test
+        void 내가_requester이면_receiver를_friend로_반환한다() {
+            // given
+            User me = givenSavedUser(userRepository);
+            User friend = givenSavedUser(userRepository, new Nickname("상대방"), new InvitationCode("FFFFFF"));
+            Long mateId = sut.requestMate(me.getId(), "FFFFFF");
+            acceptMate(mateId);
+
+            // when
+            List<MateInfo> result = sut.getAcceptedMates(me.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).nickname()).isEqualTo("상대방");
+            assertThat(result.get(0).invitationCode()).isEqualTo("FFFFFF");
+        }
+
+        @Test
+        void 내가_receiver이면_requester를_friend로_반환한다() {
+            // given
+            User requester = givenSavedUser(userRepository, new Nickname("요청자"), new InvitationCode("RRRRRR"));
+            User me = givenSavedUser(userRepository, new Nickname("나"), new InvitationCode("MMMMMM"));
+            Long mateId = sut.requestMate(requester.getId(), "MMMMMM");
+            acceptMate(mateId);
+
+            // when
+            List<MateInfo> result = sut.getAcceptedMates(me.getId());
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).nickname()).isEqualTo("요청자");
+            assertThat(result.get(0).invitationCode()).isEqualTo("RRRRRR");
+        }
+
+        private void acceptMate(Long mateId) {
+            Mate mate = mateRepository.findById(mateId).orElseThrow();
+            mate.accept();
+            mateRepository.save(mate);
         }
     }
 }

--- a/src/test/java/com/example/demo/application/MateServiceTest.java
+++ b/src/test/java/com/example/demo/application/MateServiceTest.java
@@ -1,0 +1,99 @@
+package com.example.demo.application;
+
+import static com.example.demo.util.DbUtils.givenSavedUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.demo.domain.InvitationCode;
+import com.example.demo.domain.MateRepository;
+import com.example.demo.domain.Nickname;
+import com.example.demo.domain.User;
+import com.example.demo.domain.UserRepository;
+import com.example.demo.domain.enums.MateStatus;
+import com.example.demo.util.AbstractIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MateServiceTest extends AbstractIntegrationTest {
+
+    @Autowired
+    MateService sut;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    MateRepository mateRepository;
+
+    @Nested
+    @DisplayName("친구 요청")
+    class RequestMate {
+
+        @Test
+        void 정상적으로_친구_요청이_생성된다() {
+            // given
+            User requester = givenSavedUser(userRepository);
+            User receiver = givenSavedUser(userRepository, new Nickname("친구"), new InvitationCode("ABCDEF"));
+
+            // when
+            Long mateId = sut.requestMate(requester.getId(), "ABCDEF");
+
+            // then
+            assertThat(mateId).isNotNull();
+            var mate = mateRepository.findById(mateId).orElseThrow();
+            assertThat(mate.getRequester().getId()).isEqualTo(requester.getId());
+            assertThat(mate.getReceiver().getId()).isEqualTo(receiver.getId());
+            assertThat(mate.getStatus()).isEqualTo(MateStatus.PENDING);
+        }
+
+        @Test
+        void 존재하지_않는_초대코드이면_예외가_발생한다() {
+            // given
+            User requester = givenSavedUser(userRepository);
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestMate(requester.getId(), "ZZZZZZ"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 초대코드입니다.");
+        }
+
+        @Test
+        void 자기_자신의_초대코드로_요청하면_예외가_발생한다() {
+            // given
+            User requester = givenSavedUser(userRepository, new Nickname("나자신"), new InvitationCode("MYSELF"));
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestMate(requester.getId(), "MYSELF"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자기 자신에게 친구 요청을 보낼 수 없습니다.");
+        }
+
+        @Test
+        void 이미_A에서_B로_관계가_존재하면_예외가_발생한다() {
+            // given
+            User requester = givenSavedUser(userRepository);
+            User receiver = givenSavedUser(userRepository, new Nickname("친구"), new InvitationCode("ABCDEF"));
+            sut.requestMate(requester.getId(), "ABCDEF");
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestMate(requester.getId(), "ABCDEF"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 친구 관계가 존재하거나 요청 대기 중입니다.");
+        }
+
+        @Test
+        void 이미_B에서_A로_관계가_존재하면_예외가_발생한다() {
+            // given
+            User userA = givenSavedUser(userRepository, new Nickname("철수"), new InvitationCode("AAAAAA"));
+            User userB = givenSavedUser(userRepository, new Nickname("영희"), new InvitationCode("BBBBBB"));
+            sut.requestMate(userB.getId(), "AAAAAA"); // B→A 요청
+
+            // when & then
+            assertThatThrownBy(() -> sut.requestMate(userA.getId(), "BBBBBB")) // A→B 요청
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 친구 관계가 존재하거나 요청 대기 중입니다.");
+        }
+    }
+}

--- a/src/test/java/com/example/demo/domain/MateTest.java
+++ b/src/test/java/com/example/demo/domain/MateTest.java
@@ -1,0 +1,151 @@
+package com.example.demo.domain;
+
+import com.example.demo.domain.enums.MateStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static com.example.demo.util.DbUtils.kakaoUser;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MateTest {
+
+    private final User requester = createUserWithId(1L, "kakao-1", "요청자", "AAAAAA");
+    private final User receiver = createUserWithId(2L, "google-1", "수신자", "BBBBBB");
+
+    private User createUserWithId(Long id, String providerId, String nickname, String code) {
+        User user = kakaoUser(providerId, new Nickname(nickname), new InvitationCode(code));
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    @Nested
+    @DisplayName("생성자 검증")
+    class ConstructorValidation {
+
+        @Test
+        void 처음_생성시_status는_PENDING() {
+            Mate mate = new Mate(requester, receiver);
+
+            assertThat(mate.getRequester()).isEqualTo(requester);
+            assertThat(mate.getReceiver()).isEqualTo(receiver);
+            assertThat(mate.getStatus()).isEqualTo(MateStatus.PENDING);
+            assertThat(mate.getAcceptedAt()).isNull();
+        }
+
+        @Test
+        void requester가_null이면_예외발생() {
+            assertThatThrownBy(() -> new Mate(null, receiver))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("요청자는 필수입니다.");
+        }
+
+        @Test
+        void receiver가_null이면_예외발생() {
+            assertThatThrownBy(() -> new Mate(requester, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("수신자는 필수입니다.");
+        }
+
+        @Test
+        void 자기자신에게_친구요청시_예외() {
+            assertThatThrownBy(() -> new Mate(requester, requester))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자기 자신에게 친구 요청을 보낼 수 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("accept 검증")
+    class AcceptValidation {
+
+        @Test
+        void 친구수락시_PENDING에서_ACCEPTED로_변경() {
+            Mate mate = new Mate(requester, receiver);
+
+            mate.accept();
+
+            assertThat(mate.getStatus()).isEqualTo(MateStatus.ACCEPTED);
+            assertThat(mate.getAcceptedAt()).isNotNull();
+        }
+
+        @Test
+        void ACCEPTED에서_친구수락_요청시_예외발생() {
+            Mate mate = new Mate(requester, receiver);
+            mate.accept();
+
+            assertThatThrownBy(mate::accept)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("대기 중인 요청만 수락할 수 있습니다.");
+        }
+
+        @Test
+        void REJECTED에서_친구수락_요청시_예외발생() {
+            Mate mate = new Mate(requester, receiver);
+            mate.reject();
+
+            assertThatThrownBy(mate::accept)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("대기 중인 요청만 수락할 수 있습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("reject 검증")
+    class RejectValidation {
+
+        @Test
+        void 친구거절시_PENDING에서_REJECTED로_변경() {
+            Mate mate = new Mate(requester, receiver);
+
+            mate.reject();
+
+            assertThat(mate.getStatus()).isEqualTo(MateStatus.REJECTED);
+        }
+
+        @Test
+        void ACCEPTED에서_친구거절_요청시_예외발생() {
+            Mate mate = new Mate(requester, receiver);
+            mate.accept();
+
+            assertThatThrownBy(mate::reject)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("대기 중인 요청만 거절할 수 있습니다.");
+        }
+
+        @Test
+        void REJECTED에서_친구거절_요청시_예외발생() {
+            Mate mate = new Mate(requester, receiver);
+            mate.reject();
+
+            assertThatThrownBy(mate::reject)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("대기 중인 요청만 거절할 수 있습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("getFriend 검증")
+    class GetFriendValidation {
+
+        @Test
+        void 내가_requester이면_receiver를_반환() {
+            Mate mate = new Mate(requester, receiver);
+
+            User friend = mate.getFriend(requester.getId());
+
+            assertThat(friend).isEqualTo(receiver);
+        }
+
+        @Test
+        void 내가_receiver이면_requester를_반환() {
+            Mate mate = new Mate(requester, receiver);
+
+            User friend = mate.getFriend(receiver.getId());
+
+            assertThat(friend).isEqualTo(requester);
+        }
+    }
+}

--- a/src/test/java/com/example/demo/domain/MateTest.java
+++ b/src/test/java/com/example/demo/domain/MateTest.java
@@ -125,27 +125,4 @@ class MateTest {
                 .hasMessage("대기 중인 요청만 거절할 수 있습니다.");
         }
     }
-
-    @Nested
-    @DisplayName("getFriend 검증")
-    class GetFriendValidation {
-
-        @Test
-        void 내가_requester이면_receiver를_반환() {
-            Mate mate = new Mate(requester, receiver);
-
-            User friend = mate.getFriend(requester.getId());
-
-            assertThat(friend).isEqualTo(receiver);
-        }
-
-        @Test
-        void 내가_receiver이면_requester를_반환() {
-            Mate mate = new Mate(requester, receiver);
-
-            User friend = mate.getFriend(receiver.getId());
-
-            assertThat(friend).isEqualTo(requester);
-        }
-    }
 }

--- a/src/test/java/com/example/demo/infrastructure/controller/MateDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/MateDocumentationTest.java
@@ -1,0 +1,658 @@
+package com.example.demo.infrastructure.controller;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+import com.example.demo.application.MateService;
+import com.example.demo.application.dto.MateInfo;
+import com.example.demo.application.dto.MateReceivedInfo;
+import com.example.demo.application.oauth.TokenProvider;
+import com.example.demo.domain.enums.MateStatus;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.example.demo.util.RestDocsUtils.allowedValues;
+import static com.example.demo.util.RestDocsUtils.enumList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MateController.class)
+@AutoConfigureRestDocs
+@Tag("restdocs")
+class MateDocumentationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MateService mateService;
+
+    @MockitoBean
+    private TokenProvider tokenProvider;
+
+    private final String accessToken = "jwt.access.token";
+
+    @BeforeEach
+    void setUpAuth() {
+        final long userId = 1L;
+        given(tokenProvider.validateAccessToken(accessToken)).willReturn(userId);
+    }
+
+    @Nested
+    @DisplayName("친구 요청 보내기")
+    class RequestMate {
+
+        @Test
+        void request_mate_docs() throws Exception {
+            // given
+            String invitationCode = "ABCDEF";
+            given(mateService.requestMate(eq(1L), eq(invitationCode))).willReturn(1L);
+
+            // when & then
+            mockMvc.perform(
+                    post("/mates")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"invitationCode\":\"" + invitationCode + "\"}")
+                )
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/mates/1"))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.mateId").value(1))
+                .andDo(document("친구 요청 보내기",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .summary("친구 요청 보내기")
+                        .description("상대방의 초대코드를 이용하여 친구 요청을 보냅니다.")
+                        .requestSchema(Schema.schema("CreateMateWebRequest"))
+                        .responseSchema(Schema.schema("MateCreateWebResponse"))
+                        .requestFields(
+                            fieldWithPath("invitationCode").type(STRING)
+                                .attributes(
+                                    key("example").value("ABCDEF"),
+                                    key("format").value("영문 대문자 6자리")
+                                )
+                                .description("상대방의 초대코드 (영문 대문자 6자리)")
+                        )
+                        .responseFields(
+                            fieldWithPath("mateId").type(NUMBER)
+                                .attributes(
+                                    key("format").value("int64"),
+                                    key("example").value(1)
+                                )
+                                .description("생성된 친구 요청 ID")
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).requestMate(eq(1L), eq(invitationCode));
+        }
+
+        @Test
+        void request_mate_fail_not_exists_invitation_code_docs() throws Exception {
+            // given
+            String invitationCode = "ZZZZZZ";
+            given(mateService.requestMate(eq(1L), eq(invitationCode)))
+                .willThrow(new IllegalArgumentException("존재하지 않는 초대코드입니다."));
+
+            // when & then
+            mockMvc.perform(
+                    post("/mates")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"invitationCode\":\"" + invitationCode + "\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 초대코드입니다."))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 보내기 - 존재하지 않는 초대코드 (초대코드에 해당하는 사용자가 존재하지 않는 경우)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .requestSchema(Schema.schema("CreateMateWebRequest"))
+                        .requestFields(
+                            fieldWithPath("invitationCode").type(STRING).description("상대방의 초대코드")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).requestMate(eq(1L), eq(invitationCode));
+        }
+
+        @Test
+        void request_mate_fail_already_exists_docs() throws Exception {
+            // given
+            String invitationCode = "ABCDEF";
+            given(mateService.requestMate(eq(1L), eq(invitationCode)))
+                .willThrow(new IllegalArgumentException("이미 친구 관계가 존재하거나 요청 대기 중입니다."));
+
+            // when & then
+            mockMvc.perform(
+                    post("/mates")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"invitationCode\":\"" + invitationCode + "\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("이미 친구 관계가 존재하거나 요청 대기 중입니다."))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 보내기 - 이미 관계 존재 (이미 친구이거나 대기 중인 요청이 있는 경우)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .requestSchema(Schema.schema("CreateMateWebRequest"))
+                        .requestFields(
+                            fieldWithPath("invitationCode").type(STRING).description("상대방의 초대코드")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).requestMate(eq(1L), eq(invitationCode));
+        }
+
+        @Test
+        void request_mate_fail_self_request_docs() throws Exception {
+            // given
+            String invitationCode = "ABCDEF";
+            given(mateService.requestMate(eq(1L), eq(invitationCode)))
+                .willThrow(new IllegalArgumentException("자기 자신에게 친구 요청을 보낼 수 없습니다."));
+
+            // when & then
+            mockMvc.perform(
+                    post("/mates")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"invitationCode\":\"" + invitationCode + "\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("자기 자신에게 친구 요청을 보낼 수 없습니다."))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 보내기 - 자기 자신에게 요청 (자기 자신의 초대코드로 친구 요청을 보낸 경우)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .requestSchema(Schema.schema("CreateMateWebRequest"))
+                        .requestFields(
+                            fieldWithPath("invitationCode").type(STRING).description("상대방의 초대코드")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).requestMate(eq(1L), eq(invitationCode));
+        }
+
+        @Test
+        void request_mate_fail_invalid_invitation_code_format_docs() throws Exception {
+            // given - 잘못된 형식의 초대코드 (영문 대문자 6자리가 아닌 경우)
+
+            // when & then
+            mockMvc.perform(
+                    post("/mates")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"invitationCode\":\"abc\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("올바르지 않은 초대 코드 형식입니다 (영어 대문자 6자리)"))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 보내기 - 잘못된 초대코드 형식 (초대코드가 영문 대문자 6자리 형식이 아닌 경우)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .requestSchema(Schema.schema("CreateMateWebRequest"))
+                        .requestFields(
+                            fieldWithPath("invitationCode").type(STRING).description("잘못된 형식의 초대코드")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 전체 조회")
+    class GetAcceptedMates {
+
+        @Test
+        void get_accepted_mates_docs() throws Exception {
+            // given
+            List<MateInfo> mateInfos = List.of(
+                new MateInfo(1L, "토끼abc", "AAAAAA"),
+                new MateInfo(2L, "고양이dd", "BBBBBB")
+            );
+            given(mateService.getAcceptedMates(eq(1L))).willReturn(mateInfos);
+
+            // when & then
+            mockMvc.perform(
+                    get("/mates")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].mateId").value(1))
+                .andExpect(jsonPath("$[0].nickname").value("토끼abc"))
+                .andExpect(jsonPath("$[0].invitationCode").value("AAAAAA"))
+                .andExpect(jsonPath("$[1].mateId").value(2))
+                .andExpect(jsonPath("$[1].nickname").value("고양이dd"))
+                .andExpect(jsonPath("$[1].invitationCode").value("BBBBBB"))
+                .andDo(document("친구 전체 조회",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .summary("친구 전체 조회")
+                        .description("수락된(ACCEPTED) 친구 목록을 조회합니다.")
+                        .responseSchema(Schema.schema("MateInfoWebResponse"))
+                        .responseFields(
+                            fieldWithPath("[].mateId").type(NUMBER)
+                                .attributes(
+                                    key("format").value("int64"),
+                                    key("example").value(1)
+                                )
+                                .description("친구 관계 ID"),
+                            fieldWithPath("[].nickname").type(STRING)
+                                .attributes(
+                                    key("example").value("토끼abc")
+                                )
+                                .description("친구의 닉네임"),
+                            fieldWithPath("[].invitationCode").type(STRING)
+                                .attributes(
+                                    key("example").value("AAAAAA"),
+                                    key("format").value("영문 대문자 6자리")
+                                )
+                                .description("친구의 초대코드")
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).getAcceptedMates(eq(1L));
+        }
+
+        @Test
+        void get_accepted_mates_empty_docs() throws Exception {
+            // given
+            given(mateService.getAcceptedMates(eq(1L))).willReturn(List.of());
+
+            // when & then
+            mockMvc.perform(
+                    get("/mates")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty())
+                .andDo(document("친구 전체 조회 - 빈 목록 (수락된 친구가 없는 경우 빈 배열 반환)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .responseSchema(Schema.schema("MateInfoWebResponse"))
+                        .build()
+                    )
+                ));
+
+            verify(mateService).getAcceptedMates(eq(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("받은 친구 요청 조회")
+    class GetReceivedRequests {
+
+        @Test
+        void get_received_requests_docs() throws Exception {
+            // given
+            List<MateReceivedInfo> receivedInfos = List.of(
+                new MateReceivedInfo(3L, "강아지ee", "CCCCCC"),
+                new MateReceivedInfo(4L, "다람쥐ff", "DDDDDD")
+            );
+            given(mateService.getReceivedRequests(eq(1L))).willReturn(receivedInfos);
+
+            // when & then
+            mockMvc.perform(
+                    get("/mates/received")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].mateId").value(3))
+                .andExpect(jsonPath("$[0].nickname").value("강아지ee"))
+                .andExpect(jsonPath("$[0].invitationCode").value("CCCCCC"))
+                .andExpect(jsonPath("$[1].mateId").value(4))
+                .andExpect(jsonPath("$[1].nickname").value("다람쥐ff"))
+                .andExpect(jsonPath("$[1].invitationCode").value("DDDDDD"))
+                .andDo(document("받은 친구 요청 조회",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .summary("받은 친구 요청 조회")
+                        .description("대기 중(PENDING)인 받은 친구 요청 목록을 조회합니다.")
+                        .responseSchema(Schema.schema("MateReceivedWebResponse"))
+                        .responseFields(
+                            fieldWithPath("[].mateId").type(NUMBER)
+                                .attributes(
+                                    key("format").value("int64"),
+                                    key("example").value(3)
+                                )
+                                .description("친구 요청 ID"),
+                            fieldWithPath("[].nickname").type(STRING)
+                                .attributes(
+                                    key("example").value("강아지ee")
+                                )
+                                .description("요청을 보낸 사용자의 닉네임"),
+                            fieldWithPath("[].invitationCode").type(STRING)
+                                .attributes(
+                                    key("example").value("CCCCCC"),
+                                    key("format").value("영문 대문자 6자리")
+                                )
+                                .description("요청을 보낸 사용자의 초대코드")
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).getReceivedRequests(eq(1L));
+        }
+
+        @Test
+        void get_received_requests_empty_docs() throws Exception {
+            // given
+            given(mateService.getReceivedRequests(eq(1L))).willReturn(List.of());
+
+            // when & then
+            mockMvc.perform(
+                    get("/mates/received")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty())
+                .andDo(document("받은 친구 요청 조회 - 빈 목록 (대기 중인 친구 요청이 없는 경우 빈 배열 반환)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .responseSchema(Schema.schema("MateReceivedWebResponse"))
+                        .build()
+                    )
+                ));
+
+            verify(mateService).getReceivedRequests(eq(1L));
+        }
+    }
+
+    @Nested
+    @DisplayName("친구 요청 수락/거절")
+    class UpdateMateStatus {
+
+        @Test
+        void accept_mate_request_docs() throws Exception {
+            // when & then
+            mockMvc.perform(
+                    patch("/mates/{mateId}", 1L)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"ACCEPTED\"}")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("친구 요청 수락",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .summary("친구 요청 수락")
+                        .description("받은 친구 요청을 수락합니다. 수신자만 수락할 수 있습니다.")
+                        .pathParameters(
+                            parameterWithName("mateId").description("친구 요청 ID")
+                        )
+                        .requestSchema(Schema.schema("UpdateMateStatusWebRequest"))
+                        .requestFields(
+                            fieldWithPath("status").type(STRING)
+                                .attributes(
+                                    key("enum").value(enumList(MateStatus.class)),
+                                    key("example").value(MateStatus.ACCEPTED.name())
+                                )
+                                .description("변경할 상태. " + allowedValues(MateStatus.class))
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).updateMateStatus(eq(1L), eq(1L), eq(MateStatus.ACCEPTED));
+        }
+
+        @Test
+        void reject_mate_request_docs() throws Exception {
+            // when & then
+            mockMvc.perform(
+                    patch("/mates/{mateId}", 2L)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"REJECTED\"}")
+                )
+                .andExpect(status().isOk())
+                .andDo(document("친구 요청 거절",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .summary("친구 요청 거절")
+                        .description("받은 친구 요청을 거절합니다. 수신자만 거절할 수 있습니다.")
+                        .pathParameters(
+                            parameterWithName("mateId").description("친구 요청 ID")
+                        )
+                        .requestSchema(Schema.schema("UpdateMateStatusWebRequest"))
+                        .requestFields(
+                            fieldWithPath("status").type(STRING)
+                                .attributes(
+                                    key("enum").value(enumList(MateStatus.class)),
+                                    key("example").value(MateStatus.REJECTED.name())
+                                )
+                                .description("변경할 상태. " + allowedValues(MateStatus.class))
+                        )
+                        .build()
+                    )
+                ));
+
+            verify(mateService).updateMateStatus(eq(2L), eq(1L), eq(MateStatus.REJECTED));
+        }
+
+        @Test
+        void update_mate_status_fail_not_found_docs() throws Exception {
+            // given
+            doThrow(new IllegalArgumentException("존재하지 않는 친구 요청입니다."))
+                .when(mateService).updateMateStatus(eq(999L), eq(1L), eq(MateStatus.ACCEPTED));
+
+            // when & then
+            mockMvc.perform(
+                    patch("/mates/{mateId}", 999L)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"ACCEPTED\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 친구 요청입니다."))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 수락/거절 - 존재하지 않는 요청 (친구 요청 ID에 해당하는 요청이 존재하지 않는 경우)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .pathParameters(
+                            parameterWithName("mateId").description("친구 요청 ID")
+                        )
+                        .requestSchema(Schema.schema("UpdateMateStatusWebRequest"))
+                        .requestFields(
+                            fieldWithPath("status").type(STRING).description("변경할 상태")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
+        }
+
+        @Test
+        void update_mate_status_fail_not_receiver_docs() throws Exception {
+            // given
+            doThrow(new IllegalArgumentException("친구 요청의 수신자만 수락/거절할 수 있습니다."))
+                .when(mateService).updateMateStatus(eq(1L), eq(1L), eq(MateStatus.ACCEPTED));
+
+            // when & then
+            mockMvc.perform(
+                    patch("/mates/{mateId}", 1L)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"ACCEPTED\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("친구 요청의 수신자만 수락/거절할 수 있습니다."))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 수락/거절 - 권한 없음 (요청의 수신자가 아닌 사용자가 수락/거절을 시도한 경우)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .pathParameters(
+                            parameterWithName("mateId").description("친구 요청 ID")
+                        )
+                        .requestSchema(Schema.schema("UpdateMateStatusWebRequest"))
+                        .requestFields(
+                            fieldWithPath("status").type(STRING).description("변경할 상태")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
+        }
+
+        @Test
+        void update_mate_status_fail_invalid_status_docs() throws Exception {
+            // when & then - 유효하지 않은 status 값
+            mockMvc.perform(
+                    patch("/mates/{mateId}", 1L)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"INVALID\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("요청 형식이 올바르지 않습니다."))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 수락/거절 - 잘못된 status 값 (status 필드가 허용되지 않는 값인 경우)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .pathParameters(
+                            parameterWithName("mateId").description("친구 요청 ID")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
+        }
+    }
+}

--- a/src/test/java/com/example/demo/infrastructure/controller/MateDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/MateDocumentationTest.java
@@ -290,8 +290,8 @@ class MateDocumentationTest {
         void get_accepted_mates_docs() throws Exception {
             // given
             List<MateInfo> mateInfos = List.of(
-                new MateInfo(1L, "토끼abc", "AAAAAA"),
-                new MateInfo(2L, "고양이dd", "BBBBBB")
+                new MateInfo(1L, "토끼abc", "AAAAAA", 3),
+                new MateInfo(2L, "고양이dd", "BBBBBB", 0)
             );
             given(mateService.getAcceptedMates(eq(1L))).willReturn(mateInfos);
 
@@ -306,9 +306,11 @@ class MateDocumentationTest {
                 .andExpect(jsonPath("$[0].mateId").value(1))
                 .andExpect(jsonPath("$[0].nickname").value("토끼abc"))
                 .andExpect(jsonPath("$[0].invitationCode").value("AAAAAA"))
+                .andExpect(jsonPath("$[0].verdictCount").value(3))
                 .andExpect(jsonPath("$[1].mateId").value(2))
                 .andExpect(jsonPath("$[1].nickname").value("고양이dd"))
                 .andExpect(jsonPath("$[1].invitationCode").value("BBBBBB"))
+                .andExpect(jsonPath("$[1].verdictCount").value(0))
                 .andDo(document("친구 전체 조회",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
@@ -334,7 +336,13 @@ class MateDocumentationTest {
                                     key("example").value("AAAAAA"),
                                     key("format").value("영문 대문자 6자리")
                                 )
-                                .description("친구의 초대코드")
+                                .description("친구의 초대코드"),
+                            fieldWithPath("[].verdictCount").type(NUMBER)
+                                .attributes(
+                                    key("format").value("int32"),
+                                    key("example").value(3)
+                                )
+                                .description("함께한 심판 횟수")
                         )
                         .build()
                     )
@@ -477,13 +485,13 @@ class MateDocumentationTest {
                         .content("{\"status\":\"ACCEPTED\"}")
                 )
                 .andExpect(status().isOk())
-                .andDo(document("친구 요청 수락",
+                .andDo(document("친구 요청 수락/거절",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     resource(ResourceSnippetParameters.builder()
                         .tag("Mate")
-                        .summary("친구 요청 수락")
-                        .description("받은 친구 요청을 수락합니다. 수신자만 수락할 수 있습니다.")
+                        .summary("친구 요청 수락/거절")
+                        .description("받은 친구 요청을 수락 또는 거절합니다. 수신자만 수락/거절할 수 있습니다.")
                         .pathParameters(
                             parameterWithName("mateId").description("친구 요청 ID")
                         )
@@ -519,8 +527,6 @@ class MateDocumentationTest {
                     preprocessResponse(prettyPrint()),
                     resource(ResourceSnippetParameters.builder()
                         .tag("Mate")
-                        .summary("친구 요청 거절")
-                        .description("받은 친구 요청을 거절합니다. 수신자만 거절할 수 있습니다.")
                         .pathParameters(
                             parameterWithName("mateId").description("친구 요청 ID")
                         )
@@ -538,6 +544,44 @@ class MateDocumentationTest {
                 ));
 
             verify(mateService).updateMateStatus(eq(2L), eq(1L), eq(MateStatus.REJECTED));
+        }
+
+        @Test
+        void update_mate_requested_status_invalid_docs() throws Exception {
+            // given
+            // when & then
+            mockMvc.perform(
+                    patch("/mates/{mateId}", 999L)
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"PENDING\"}")
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.message").value("친구요청은 수락 또는 거절로만 변경 가능합니다."))
+                .andExpect(jsonPath("$.timestamp").exists())
+                .andDo(document("친구 요청 수락/거절 - 잘못된 status로 요청 (PENDING으로 상태 변경 불가능)",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(ResourceSnippetParameters.builder()
+                        .tag("Mate")
+                        .pathParameters(
+                            parameterWithName("mateId").description("친구 요청 ID")
+                        )
+                        .requestSchema(Schema.schema("UpdateMateStatusWebRequest"))
+                        .requestFields(
+                            fieldWithPath("status").type(STRING).description("변경할 상태")
+                        )
+                        .responseSchema(Schema.schema("ErrorResponse"))
+                        .responseFields(
+                            fieldWithPath("message").type(STRING).description("에러 메시지"),
+                            fieldWithPath("timestamp").type(STRING).description("예외 발생 시각")
+                        )
+                        .build()
+                    )
+                ));
         }
 
         @Test

--- a/src/test/java/com/example/demo/infrastructure/controller/MateDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/MateDocumentationTest.java
@@ -22,8 +22,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static com.example.demo.util.RestDocsUtils.allowedValues;
-import static com.example.demo.util.RestDocsUtils.enumList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
@@ -34,7 +32,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -499,10 +496,10 @@ class MateDocumentationTest {
                         .requestFields(
                             fieldWithPath("status").type(STRING)
                                 .attributes(
-                                    key("enum").value(enumList(MateStatus.class)),
+                                    key("enum").value(List.of("ACCEPTED", "REJECTED")),
                                     key("example").value(MateStatus.ACCEPTED.name())
                                 )
-                                .description("변경할 상태. " + allowedValues(MateStatus.class))
+                                .description("변경할 상태. 허용 값: [ACCEPTED, REJECTED]")
                         )
                         .build()
                     )
@@ -534,10 +531,10 @@ class MateDocumentationTest {
                         .requestFields(
                             fieldWithPath("status").type(STRING)
                                 .attributes(
-                                    key("enum").value(enumList(MateStatus.class)),
+                                    key("enum").value(List.of("ACCEPTED", "REJECTED")),
                                     key("example").value(MateStatus.REJECTED.name())
                                 )
-                                .description("변경할 상태. " + allowedValues(MateStatus.class))
+                                .description("변경할 상태. 허용 값: [ACCEPTED, REJECTED]")
                         )
                         .build()
                     )
@@ -549,6 +546,9 @@ class MateDocumentationTest {
         @Test
         void update_mate_requested_status_invalid_docs() throws Exception {
             // given
+            doThrow(new IllegalArgumentException("친구요청은 수락 또는 거절로만 변경 가능합니다."))
+                .when(mateService).updateMateStatus(eq(999L), eq(1L), eq(MateStatus.PENDING));
+
             // when & then
             mockMvc.perform(
                     patch("/mates/{mateId}", 999L)


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 작업 요약을 한 줄로 적어주세요")

## 이슈
- Close #58 

## 요약
- [x] 친구 요청 보내기
- [x] 친구 전체 조회
- [x] 친구 요청 전체 조회
- [x] 친구 요청 수락/거절

## 설계 의도 / 결정 사항
현재 친구 요청 거절 시 Mate 상태를 REJECTED로 변경해 보관하고 있는데, 이 방식은 재요청 시 새로운 Mate가 생성됩니다. 
그래서 거절 시 해당 데이터를 삭제(Hard Delete)하고, DB 수준에서 (requester, receiver) 복합 유니크 제약 조건을 걸어 데이터 정합성을 강제하는 방안을 고민 중입니다. 이렇게 하면 중복 데이터 문제를 해결할 수 있을 것 같은데, 기석님은 생각은 어떠신가요?

```sql
CREATE UNIQUE INDEX uk_mate_symmetric_relation ON mate (
    (LEAST(requester_id, receiver_id)), 
    (GREATEST(requester_id, receiver_id))
);
```


## 리뷰 요청 / 고민 포인트
- 친구 전체 조회 시 `함께 한 심판 횟수`는 소비심판과 머지한 후에 따로 브랜치파서 구현하겠습니다. 

