### PR TITLE
[hotfix] main 브랜치 머지 시에만 개발서버 배포되도록 변경

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -2,7 +2,7 @@ name: Backend Dev CD
 
 on:
   push:
-    branches: [ "**" ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 작업 요약을 한 줄로 적어주세요")

## 이슈
- Close #61 

## 요약
- 모니터링 관련해서 작업하시고 변경 안하신 거 같습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 개발 배포 워크플로우의 자동 트리거를 main 브랜치 push로만 제한했습니다. 이제 다른 브랜치의 변경사항은 자동 배포를 실행하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->