### PR TITLE
친구 목록 조회 시 함께한 심판 횟수 반환 및 사용자 정보에 초대코드 추가  

### DIFF
--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -3,11 +3,15 @@ package com.example.demo.application;
 import com.example.demo.application.dto.MateInfo;
 import com.example.demo.application.dto.MateReceivedInfo;
 import com.example.demo.domain.Mate;
+import com.example.demo.domain.FriendVerdictCount;
 import com.example.demo.domain.MateRepository;
 import com.example.demo.domain.User;
 import com.example.demo.domain.UserRepository;
+import com.example.demo.domain.VerdictRepository;
 import com.example.demo.domain.enums.MateStatus;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +22,7 @@ public class MateService {
 
     private final MateRepository mateRepository;
     private final UserRepository userRepository;
+    private final VerdictRepository verdictRepository;
 
     @Transactional
     public Long requestMate(Long userId, String invitationCode) {
@@ -35,12 +40,15 @@ public class MateService {
 
     @Transactional(readOnly = true)
     public List<MateInfo> getAcceptedMates(Long userId) {
+        Map<Long, Long> verdictCounts = verdictRepository.countVerdictsByFriend(userId).stream()
+            .collect(Collectors.toMap(FriendVerdictCount::friendId, FriendVerdictCount::count));
+
         return mateRepository.findAllAcceptedWithFriend(userId).stream()
             .map(result -> new MateInfo(
                 result.mate().getId(),
                 result.friend().getNickname(),
                 result.friend().getInvitationCode().value(),
-                0 // TODO: 함께한 심판 횟수를 조회하여 반환
+                verdictCounts.getOrDefault(result.friend().getId(), 0L).intValue()
             ))
             .toList();
     }

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -12,6 +12,7 @@ import com.example.demo.domain.enums.MateStatus;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,8 +41,14 @@ public class MateService {
 
     @Transactional(readOnly = true)
     public List<MateInfo> getAcceptedMates(Long userId) {
-        Map<Long, Long> verdictCounts = verdictRepository.countVerdictsByFriend(userId).stream()
-            .collect(Collectors.toMap(FriendVerdictCount::friendId, FriendVerdictCount::count));
+        Map<Long, Long> verdictCounts = Stream.concat(
+                verdictRepository.countVerdictsAsOwner(userId).stream(),
+                verdictRepository.countVerdictsAsJuror(userId).stream()
+            ).collect(Collectors.toMap(
+                FriendVerdictCount::friendId,
+                FriendVerdictCount::count,
+                Long::sum
+            ));
 
         return mateRepository.findAllAcceptedWithFriend(userId).stream()
             .map(result -> new MateInfo(

--- a/src/main/java/com/example/demo/application/dto/UserInfo.java
+++ b/src/main/java/com/example/demo/application/dto/UserInfo.java
@@ -6,14 +6,16 @@ public record UserInfo(
     Long userId,
     String nickname,
     Integer level,
-    String profile
+    String profile,
+    String invitationCode
 ) {
     public static UserInfo from(User user) {
         return new UserInfo(
             user.getId(),
             user.getNickname(),
             user.getLevel(),
-            user.getProfile()
+            user.getProfile(),
+            user.getInvitationCode().value()
         );
     }
 }

--- a/src/main/java/com/example/demo/application/user/UserService.java
+++ b/src/main/java/com/example/demo/application/user/UserService.java
@@ -29,7 +29,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserInfo getUserInfo(Long userId) {
         User user = findUserById(userId);
-        return new UserInfo(user.getId(), user.getNickname(), user.getLevel(), user.getProfile(), user.getInvitationCode().value());
+        return UserInfo.from(user);
     }
 
     @Transactional

--- a/src/main/java/com/example/demo/application/user/UserService.java
+++ b/src/main/java/com/example/demo/application/user/UserService.java
@@ -29,7 +29,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserInfo getUserInfo(Long userId) {
         User user = findUserById(userId);
-        return new UserInfo(user.getId(), user.getNickname(), user.getLevel(), user.getProfile());
+        return new UserInfo(user.getId(), user.getNickname(), user.getLevel(), user.getProfile(), user.getInvitationCode().value());
     }
 
     @Transactional

--- a/src/main/java/com/example/demo/domain/FriendVerdictCount.java
+++ b/src/main/java/com/example/demo/domain/FriendVerdictCount.java
@@ -1,0 +1,5 @@
+package com.example.demo.domain;
+
+public record FriendVerdictCount(Long friendId, long count) {
+
+}

--- a/src/main/java/com/example/demo/domain/VerdictRepository.java
+++ b/src/main/java/com/example/demo/domain/VerdictRepository.java
@@ -25,15 +25,18 @@ public interface VerdictRepository extends Repository<Verdict, Long> {
     List<Verdict> findJurorVerdicts(@Param("userId") Long userId);
 
     @Query("""
-        SELECT new com.example.demo.domain.FriendVerdictCount(
-            CASE WHEN v.ledgerEntry.user.id = :userId THEN v.juror.id
-                 ELSE v.ledgerEntry.user.id END,
-            COUNT(v)
-        )
+        SELECT new com.example.demo.domain.FriendVerdictCount(v.juror.id, COUNT(v))
         FROM Verdict v
-        WHERE v.ledgerEntry.user.id = :userId OR v.juror.id = :userId
-        GROUP BY CASE WHEN v.ledgerEntry.user.id = :userId THEN v.juror.id
-                      ELSE v.ledgerEntry.user.id END
+        WHERE v.ledgerEntry.user.id = :userId
+        GROUP BY v.juror.id
         """)
-    List<FriendVerdictCount> countVerdictsByFriend(@Param("userId") Long userId);
+    List<FriendVerdictCount> countVerdictsAsOwner(@Param("userId") Long userId);
+
+    @Query("""
+        SELECT new com.example.demo.domain.FriendVerdictCount(v.ledgerEntry.user.id, COUNT(v))
+        FROM Verdict v
+        WHERE v.juror.id = :userId
+        GROUP BY v.ledgerEntry.user.id
+        """)
+    List<FriendVerdictCount> countVerdictsAsJuror(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/demo/domain/VerdictRepository.java
+++ b/src/main/java/com/example/demo/domain/VerdictRepository.java
@@ -23,4 +23,17 @@ public interface VerdictRepository extends Repository<Verdict, Long> {
         select v from Verdict v where v.juror.id = :userId
         """)
     List<Verdict> findJurorVerdicts(@Param("userId") Long userId);
+
+    @Query("""
+        SELECT new com.example.demo.domain.FriendVerdictCount(
+            CASE WHEN v.ledgerEntry.user.id = :userId THEN v.juror.id
+                 ELSE v.ledgerEntry.user.id END,
+            COUNT(v)
+        )
+        FROM Verdict v
+        WHERE v.ledgerEntry.user.id = :userId OR v.juror.id = :userId
+        GROUP BY CASE WHEN v.ledgerEntry.user.id = :userId THEN v.juror.id
+                      ELSE v.ledgerEntry.user.id END
+        """)
+    List<FriendVerdictCount> countVerdictsByFriend(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/MateController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/MateController.java
@@ -5,6 +5,7 @@ import com.example.demo.infrastructure.controller.dto.CreateMateWebRequest;
 import com.example.demo.infrastructure.controller.dto.MateCreateWebResponse;
 import com.example.demo.infrastructure.controller.dto.MateInfoWebResponse;
 import com.example.demo.infrastructure.controller.dto.MateReceivedWebResponse;
+import com.example.demo.infrastructure.controller.dto.MateUpdateWebResponse;
 import com.example.demo.infrastructure.controller.dto.UpdateMateStatusWebRequest;
 import com.example.demo.infrastructure.interceptor.UserId;
 import jakarta.validation.Valid;
@@ -54,12 +55,12 @@ public class MateController {
     }
 
     @PatchMapping("/mates/{mateId}")
-    public ResponseEntity<Void> updateMateStatus(
+    public ResponseEntity<MateUpdateWebResponse> updateMateStatus(
         @UserId Long userId,
         @PathVariable Long mateId,
         @Valid @RequestBody UpdateMateStatusWebRequest request
     ) {
         mateService.updateMateStatus(mateId, userId, request.status());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new MateUpdateWebResponse(mateId));
     }
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/MateUpdateWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/MateUpdateWebResponse.java
@@ -1,0 +1,4 @@
+package com.example.demo.infrastructure.controller.dto;
+
+public record MateUpdateWebResponse(Long mateId) {
+}

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/UserInfoWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/UserInfoWebResponse.java
@@ -5,13 +5,15 @@ import com.example.demo.application.dto.UserInfo;
 public record UserInfoWebResponse(
     Long id,
     String nickname,
-    Integer level
+    Integer level,
+    String invitationCode
 ) {
     public static UserInfoWebResponse from(UserInfo userInfo) {
         return new UserInfoWebResponse(
             userInfo.userId(),
             userInfo.nickname(),
-            userInfo.level()
+            userInfo.level(),
+            userInfo.invitationCode()
         );
     }
 }

--- a/src/test/java/com/example/demo/application/MateServiceTest.java
+++ b/src/test/java/com/example/demo/application/MateServiceTest.java
@@ -3,13 +3,20 @@ package com.example.demo.application;
 import com.example.demo.application.dto.MateInfo;
 import com.example.demo.application.dto.MateReceivedInfo;
 import com.example.demo.domain.InvitationCode;
+import com.example.demo.domain.LedgerEntry;
+import com.example.demo.domain.LedgerEntryRepository;
 import com.example.demo.domain.Mate;
 import com.example.demo.domain.MateRepository;
 import com.example.demo.domain.Nickname;
 import com.example.demo.domain.User;
 import com.example.demo.domain.UserRepository;
+import com.example.demo.domain.VerdictRepository;
+import com.example.demo.domain.enums.LedgerCategory;
+import com.example.demo.domain.enums.LedgerType;
 import com.example.demo.domain.enums.MateStatus;
+import com.example.demo.domain.enums.PaymentMethod;
 import com.example.demo.util.AbstractIntegrationTest;
+import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -30,6 +37,12 @@ class MateServiceTest extends AbstractIntegrationTest {
 
     @Autowired
     MateRepository mateRepository;
+
+    @Autowired
+    VerdictRepository verdictRepository;
+
+    @Autowired
+    LedgerEntryRepository ledgerEntryRepository;
 
     @Nested
     @DisplayName("친구 요청")
@@ -144,6 +157,45 @@ class MateServiceTest extends AbstractIntegrationTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).nickname()).isEqualTo("상대방");
             assertThat(result.get(0).invitationCode()).isEqualTo("FFFFFF");
+        }
+
+        @Test
+        void 친구와_함께한_심판_횟수가_반환된다() {
+            // given
+            User me = givenSavedUser(userRepository);
+            User friend1 = givenSavedUser(userRepository, new Nickname("친구1"), new InvitationCode("FFAAAA"));
+            User friend2 = givenSavedUser(userRepository, new Nickname("친구2"), new InvitationCode("FFBBBB"));
+
+            Long mateId1 = sut.requestMate(me.getId(), "FFAAAA");
+            Long mateId2 = sut.requestMate(me.getId(), "FFBBBB");
+            acceptMate(mateId1);
+            acceptMate(mateId2);
+
+            // 내 가계부 항목에 friend1이 배심원인 심판 2건
+            LedgerEntry myEntry1 = ledgerEntryRepository.save(
+                new LedgerEntry(10000L, LedgerType.EXPENSE, LedgerCategory.FOOD, "점심", LocalDate.now(), PaymentMethod.CASH, null, me));
+            verdictRepository.save(myEntry1.requestVerdict(friend1));
+
+            LedgerEntry myEntry2 = ledgerEntryRepository.save(
+                new LedgerEntry(20000L, LedgerType.EXPENSE, LedgerCategory.SHOPPING, "옷", LocalDate.now(), PaymentMethod.CREDIT_CARD, null, me));
+            verdictRepository.save(myEntry2.requestVerdict(friend1));
+
+            // friend1의 가계부 항목에 내가 배심원인 심판 1건
+            LedgerEntry friendEntry = ledgerEntryRepository.save(
+                new LedgerEntry(5000L, LedgerType.EXPENSE, LedgerCategory.FOOD, "커피", LocalDate.now(), PaymentMethod.CASH, null, friend1));
+            verdictRepository.save(friendEntry.requestVerdict(me));
+
+            // when
+            List<MateInfo> result = sut.getAcceptedMates(me.getId());
+
+            // then
+            assertThat(result).hasSize(2);
+            MateInfo friend1Info = result.stream()
+                .filter(m -> m.nickname().equals("친구1")).findFirst().orElseThrow();
+            MateInfo friend2Info = result.stream()
+                .filter(m -> m.nickname().equals("친구2")).findFirst().orElseThrow();
+            assertThat(friend1Info.verdictCount()).isEqualTo(3);
+            assertThat(friend2Info.verdictCount()).isEqualTo(0);
         }
 
         @Test

--- a/src/test/java/com/example/demo/infrastructure/controller/UserDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/UserDocumentationTest.java
@@ -358,7 +358,7 @@ class UserDocumentationTest {
             // given
             Long userId = 1L;
             String accessToken = "test-access-token";
-            UserInfo userInfo = new UserInfo(userId, "토끼abc", 1, "profile.jpg");
+            UserInfo userInfo = new UserInfo(userId, "토끼abc", 1, "profile.jpg", "AAAAAA");
 
             given(tokenProvider.validateAccessToken(accessToken)).willReturn(userId);
             given(userService.getUserInfo(userId)).willReturn(userInfo);
@@ -374,6 +374,7 @@ class UserDocumentationTest {
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.nickname").value("토끼abc"))
                 .andExpect(jsonPath("$.level").value(1))
+                .andExpect(jsonPath("$.invitationCode").value("AAAAAA"))
                 .andDo(document("사용자 정보 조회",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
@@ -385,7 +386,8 @@ class UserDocumentationTest {
                         .responseFields(
                             fieldWithPath("id").type(NUMBER).description("사용자의 id"),
                             fieldWithPath("nickname").type(STRING).description("사용자 닉네임 (설정하지 않은 경우 랜덤 닉네임)"),
-                            fieldWithPath("level").type(NUMBER).description("사용자 레벨 (기본값: 0)")
+                            fieldWithPath("level").type(NUMBER).description("사용자 레벨 (기본값: 0)"),
+                            fieldWithPath("invitationCode").type(STRING).description("사용자 초대코드")
                         )
                         .build()
                     )

--- a/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
@@ -430,9 +430,9 @@ class VerdictDocumentationTest {
             String accessToken = "test-access-token";
 
             JurorVerdicts jurorVerdicts = new JurorVerdicts(List.of(
-                new JurorVerdict(1L, new UserInfo(2L, "토끼abc", 1, "profile.jpg"),
+                new JurorVerdict(1L, new UserInfo(2L, "토끼abc", 1, "profile.jpg", "AAAAAA"),
                     new LedgerEntryInfo(1L, 7000L, LedgerCategory.FOOD, "커피"), VerdictType.GUILTY),
-                new JurorVerdict(2L, new UserInfo(3L, "강아지123", 2, "profile2.jpg"),
+                new JurorVerdict(2L, new UserInfo(3L, "강아지123", 2, "profile2.jpg", "BBBBBB"),
                     new LedgerEntryInfo(2L, 15000L, LedgerCategory.FOOD, "점심"), null)
             ));
 
@@ -460,6 +460,7 @@ class VerdictDocumentationTest {
                             fieldWithPath("jurorVerdicts[].defendantInfo.id").type(NUMBER).description("피고 유저 ID"),
                             fieldWithPath("jurorVerdicts[].defendantInfo.nickname").type(STRING).description("피고 닉네임"),
                             fieldWithPath("jurorVerdicts[].defendantInfo.level").type(NUMBER).description("피고 레벨"),
+                            fieldWithPath("jurorVerdicts[].defendantInfo.invitationCode").type(STRING).description("피고 초대코드"),
                             fieldWithPath("jurorVerdicts[].ledgerEntryInfo.id").type(NUMBER).description("소비 내역 ID"),
                             fieldWithPath("jurorVerdicts[].ledgerEntryInfo.amount").type(NUMBER).description("소비 금액"),
                             fieldWithPath("jurorVerdicts[].ledgerEntryInfo.category").type(STRING)


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 작업 요약을 한 줄로 적어주세요")

## 이슈
- Close #68 

## 요약
- [x] 친구 목록 조회 시 함께한 심판(Verdict) 횟수를 계산하여 반환
- [x] 사용자 정보 조회 응답에 초대코드(invitationCode) 필드 추가
- [x] 친구 수락/거절 API 응답에 mateId 포함

## 설계 의도 / 결정 사항
- 왜 이렇게 구현했는지, 핵심 선택(트레이드오프)을 적어주세요.

## 리뷰 요청 / 고민 포인트
- 리뷰어가 봐줬으면 하는 부분 (설계, 예외처리, 네이밍, 성능 등)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 친구별 판결 수를 집계해 프로필에 표시
  * 사용자 정보에 초대 코드(invitationCode) 필드 추가(API 응답 노출)
  * 친구 상태 업데이트 응답에 친구 ID 포함

* **Tests**
  * 판결 수 집계 시나리오 검증 테스트 추가
  * 사용자 정보 응답에 초대 코드 포함하도록 문서 및 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->