### PR TITLE
내 소비 심판 응답값에 배심원 정보 포함

### DIFF
--- a/src/main/java/com/example/demo/application/dto/MyVerdict.java
+++ b/src/main/java/com/example/demo/application/dto/MyVerdict.java
@@ -7,6 +7,7 @@ import com.example.demo.domain.VerdictType;
 public record MyVerdict(
     Long id,
     LedgerEntryInfo ledgerEntryInfo,
+    UserInfo juror,
     VerdictType verdictType
 ) {
     public static MyVerdict from(Verdict verdict) {
@@ -15,6 +16,7 @@ public record MyVerdict(
         return new MyVerdict(
             verdict.getId(),
             LedgerEntryInfo.from(ledgerEntry),
+            UserInfo.from(verdict.getJuror()),
             verdict.getType()
         );
     }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/MyVerdictWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/MyVerdictWebResponse.java
@@ -2,13 +2,12 @@ package com.example.demo.infrastructure.controller.dto;
 
 import com.example.demo.application.dto.LedgerEntryInfo;
 import com.example.demo.application.dto.MyVerdict;
-import com.example.demo.application.dto.UserInfo;
 import com.example.demo.domain.VerdictType;
 
 public record MyVerdictWebResponse(
     Long id,
     LedgerEntryInfoWebResponse ledgerEntryInfo,
-    UserInfo juror,
+    UserInfoWebResponse juror,
     VerdictType verdictType
 ) {
     public static MyVerdictWebResponse from(MyVerdict myVerdict) {
@@ -23,7 +22,7 @@ public record MyVerdictWebResponse(
                 ledgerEntryInfo.paymentMethod(),
                 ledgerEntryInfo.description()
             ),
-            myVerdict.juror(),
+            UserInfoWebResponse.from(myVerdict.juror()),
             myVerdict.verdictType()
         );
     }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/MyVerdictWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/MyVerdictWebResponse.java
@@ -2,11 +2,13 @@ package com.example.demo.infrastructure.controller.dto;
 
 import com.example.demo.application.dto.LedgerEntryInfo;
 import com.example.demo.application.dto.MyVerdict;
+import com.example.demo.application.dto.UserInfo;
 import com.example.demo.domain.VerdictType;
 
 public record MyVerdictWebResponse(
     Long id,
     LedgerEntryInfoWebResponse ledgerEntryInfo,
+    UserInfo juror,
     VerdictType verdictType
 ) {
     public static MyVerdictWebResponse from(MyVerdict myVerdict) {
@@ -21,6 +23,7 @@ public record MyVerdictWebResponse(
                 ledgerEntryInfo.paymentMethod(),
                 ledgerEntryInfo.description()
             ),
+            myVerdict.juror(),
             myVerdict.verdictType()
         );
     }

--- a/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
@@ -494,14 +494,12 @@ class VerdictDocumentationTest {
                                 .description("결제 수단. " + allowedValues(PaymentMethod.class)),
                             fieldWithPath("verdicts[].ledgerEntryInfo.description").type(STRING)
                                 .description("소비 내용"),
-                            fieldWithPath("verdicts[].juror.userId").type(NUMBER)
+                            fieldWithPath("verdicts[].juror.id").type(NUMBER)
                                     .description("배심원 id"),
                             fieldWithPath("verdicts[].juror.nickname").type(STRING)
                                     .description("배심원 닉네임"),
                             fieldWithPath("verdicts[].juror.level").type(NUMBER)
                                 .description("배심원 레벨"),
-                            fieldWithPath("verdicts[].juror.profile").type(NULL)
-                                .description("배심원 프로필 사진 url"),
                             fieldWithPath("verdicts[].juror.invitationCode").type(STRING)
                                 .description("배심원 초대코드"),
                             fieldWithPath("verdicts[].verdictType").type(STRING).optional()

--- a/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
@@ -15,6 +15,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
+import static org.springframework.restdocs.payload.JsonFieldType.NULL;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -35,6 +36,10 @@ import com.example.demo.application.dto.MyVerdicts;
 import com.example.demo.application.dto.UserInfo;
 import com.example.demo.application.exception.UnauthorizedException;
 import com.example.demo.application.oauth.TokenProvider;
+import com.example.demo.domain.InvitationCode;
+import com.example.demo.domain.Nickname;
+import com.example.demo.domain.Provider;
+import com.example.demo.domain.User;
 import com.example.demo.domain.VerdictType;
 import com.example.demo.domain.enums.LedgerCategory;
 import com.example.demo.domain.enums.PaymentMethod;
@@ -437,8 +442,18 @@ class VerdictDocumentationTest {
             String accessToken = "test-access-token";
 
             MyVerdicts myVerdicts = new MyVerdicts(List.of(
-                new MyVerdict(1L, new LedgerEntryInfo(1L, 7000L, LedgerCategory.FOOD, PaymentMethod.CREDIT_CARD, "커피"), VerdictType.GUILTY),
-                new MyVerdict(2L, new LedgerEntryInfo(2L, 15000L, LedgerCategory.FOOD, PaymentMethod.CREDIT_CARD, "점심"), VerdictType.PENDING)
+                new MyVerdict(
+                    1L,
+                    new LedgerEntryInfo(1L, 7000L, LedgerCategory.FOOD, PaymentMethod.CREDIT_CARD, "커피"),
+                    new UserInfo(1L, "juror", 0, null, "ABCDEF"),
+                    VerdictType.GUILTY
+                ),
+                new MyVerdict(
+                    2L,
+                    new LedgerEntryInfo(2L, 15000L, LedgerCategory.FOOD, PaymentMethod.CREDIT_CARD, "점심"),
+                    new UserInfo(1L, "juror", 0, null, "ABCDEF"),
+                    VerdictType.PENDING
+                )
             ));
 
             given(tokenProvider.validateAccessToken(accessToken)).willReturn(userId);
@@ -479,6 +494,16 @@ class VerdictDocumentationTest {
                                 .description("결제 수단. " + allowedValues(PaymentMethod.class)),
                             fieldWithPath("verdicts[].ledgerEntryInfo.description").type(STRING)
                                 .description("소비 내용"),
+                            fieldWithPath("verdicts[].juror.userId").type(NUMBER)
+                                    .description("배심원 id"),
+                            fieldWithPath("verdicts[].juror.nickname").type(STRING)
+                                    .description("배심원 닉네임"),
+                            fieldWithPath("verdicts[].juror.level").type(NUMBER)
+                                .description("배심원 레벨"),
+                            fieldWithPath("verdicts[].juror.profile").type(NULL)
+                                .description("배심원 프로필 사진 url"),
+                            fieldWithPath("verdicts[].juror.invitationCode").type(STRING)
+                                .description("배심원 초대코드"),
                             fieldWithPath("verdicts[].verdictType").type(STRING).optional()
                                 .description("판결 결과 (GUILTY / NOT_GUILTY / PENDING: 미판결)")
                         )

--- a/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
+++ b/src/test/java/com/example/demo/infrastructure/controller/VerdictDocumentationTest.java
@@ -15,7 +15,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
-import static org.springframework.restdocs.payload.JsonFieldType.NULL;
 import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -36,10 +35,6 @@ import com.example.demo.application.dto.MyVerdicts;
 import com.example.demo.application.dto.UserInfo;
 import com.example.demo.application.exception.UnauthorizedException;
 import com.example.demo.application.oauth.TokenProvider;
-import com.example.demo.domain.InvitationCode;
-import com.example.demo.domain.Nickname;
-import com.example.demo.domain.Provider;
-import com.example.demo.domain.User;
 import com.example.demo.domain.VerdictType;
 import com.example.demo.domain.enums.LedgerCategory;
 import com.example.demo.domain.enums.PaymentMethod;


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 작업 요약을 한 줄로 적어주세요")

## 이슈
- Close #72 

## 요약
- 요청에 따라 소비 심판 응답값에 배심원 정보를 포함합니다.
<img width="417" height="393" alt="스크린샷 2026-02-27 20 40 48" src="https://github.com/user-attachments/assets/b84dd914-2d82-4e22-8ba0-b019d48e4009" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 판결 응답에 배심원 정보가 포함됨 — 배심원 프로필(예: ID, 닉네임, 레벨, 초대 코드 등)을 판결 항목에서 확인할 수 있습니다.
* **테스트·문서**
  * API 응답 스키마와 테스트·문서가 배심원 필드 추가에 맞춰 갱신되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->