### PR TITLE
Mate 도메인 리팩토링 및 친구 요청 동시성 문제 수정

### DIFF
--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -2,8 +2,8 @@ package com.example.demo.application;
 
 import com.example.demo.application.dto.MateInfo;
 import com.example.demo.application.dto.MateReceivedInfo;
-import com.example.demo.domain.Mate;
 import com.example.demo.domain.FriendVerdictCount;
+import com.example.demo.domain.Mate;
 import com.example.demo.domain.MateRepository;
 import com.example.demo.domain.User;
 import com.example.demo.domain.UserRepository;
@@ -48,13 +48,13 @@ public class MateService {
     @Transactional(readOnly = true)
     public List<MateInfo> getAcceptedMates(Long userId) {
         Map<Long, Long> verdictCounts = Stream.concat(
-                verdictRepository.countVerdictsAsOwner(userId).stream(),
-                verdictRepository.countVerdictsAsJuror(userId).stream()
-            ).collect(Collectors.toMap(
-                FriendVerdictCount::friendId,
-                FriendVerdictCount::count,
-                Long::sum
-            ));
+            verdictRepository.countVerdictsAsOwner(userId).stream(),
+            verdictRepository.countVerdictsAsJuror(userId).stream()
+        ).collect(Collectors.toMap(
+            FriendVerdictCount::friendId,
+            FriendVerdictCount::count,
+            Long::sum
+        ));
 
         return mateRepository.findAllAcceptedWithFriend(userId).stream()
             .map(result -> new MateInfo(

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -78,10 +78,7 @@ public class MateService {
         switch (status) {
             case ACCEPTED -> mate.accept();
             case REJECTED -> {
-                // 거절 시 Mate 삭제 (다시 요청 가능하도록)
-                if (mate.getStatus() != MateStatus.PENDING) {
-                    throw new IllegalArgumentException("대기 중인 요청만 거절할 수 있습니다.");
-                }
+                mate.validateIsPending();
                 mateRepository.delete(mate);
             }
             default -> throw new IllegalArgumentException("친구요청은 수락 또는 거절로만 변경 가능합니다.");

--- a/src/main/java/com/example/demo/application/MateService.java
+++ b/src/main/java/com/example/demo/application/MateService.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,7 +37,12 @@ public class MateService {
             throw new IllegalArgumentException("이미 친구 관계가 존재하거나 요청 대기 중입니다.");
         }
 
-        return mateRepository.save(new Mate(requester, receiver)).getId();
+        try {
+            return mateRepository.save(new Mate(requester, receiver)).getId();
+        } catch (DataIntegrityViolationException e) {
+            // 동시성으로 인한 중복 저장 시도 시 DB 유니크 제약 위반
+            throw new IllegalArgumentException("이미 친구 관계가 존재하거나 요청 대기 중입니다.");
+        }
     }
 
     @Transactional(readOnly = true)
@@ -71,7 +77,13 @@ public class MateService {
 
         switch (status) {
             case ACCEPTED -> mate.accept();
-            case REJECTED -> mate.reject();
+            case REJECTED -> {
+                // 거절 시 Mate 삭제 (다시 요청 가능하도록)
+                if (mate.getStatus() != MateStatus.PENDING) {
+                    throw new IllegalArgumentException("대기 중인 요청만 거절할 수 있습니다.");
+                }
+                mateRepository.delete(mate);
+            }
             default -> throw new IllegalArgumentException("친구요청은 수락 또는 거절로만 변경 가능합니다.");
         }
     }

--- a/src/main/java/com/example/demo/domain/Mate.java
+++ b/src/main/java/com/example/demo/domain/Mate.java
@@ -66,11 +66,10 @@ public class Mate extends BaseEntity {
         this.status = MateStatus.ACCEPTED;
     }
 
-    public void reject() {
+    public void validateIsPending() {
         if (this.status != MateStatus.PENDING) {
             throw new IllegalArgumentException("대기 중인 요청만 거절할 수 있습니다.");
         }
-        this.status = MateStatus.REJECTED;
     }
 
     public User getOtherUser(User me) {

--- a/src/main/java/com/example/demo/domain/Mate.java
+++ b/src/main/java/com/example/demo/domain/Mate.java
@@ -54,7 +54,7 @@ public class Mate extends BaseEntity {
         if (receiver == null) {
             throw new IllegalArgumentException("수신자는 필수입니다.");
         }
-        if (requester.getId().equals(receiver.getId())) {
+        if (requester.equals(receiver)) {
             throw new IllegalArgumentException("자기 자신에게 친구 요청을 보낼 수 없습니다.");
         }
         this.requester = requester;

--- a/src/main/java/com/example/demo/domain/Mate.java
+++ b/src/main/java/com/example/demo/domain/Mate.java
@@ -13,7 +13,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -45,8 +44,6 @@ public class Mate extends BaseEntity {
     @Column(nullable = false)
     private MateStatus status;
 
-    private LocalDateTime acceptedAt;
-
     public Mate(User requester, User receiver) {
         if (requester == null) {
             throw new IllegalArgumentException("요청자는 필수입니다.");
@@ -67,7 +64,6 @@ public class Mate extends BaseEntity {
             throw new IllegalArgumentException("대기 중인 요청만 수락할 수 있습니다.");
         }
         this.status = MateStatus.ACCEPTED;
-        this.acceptedAt = LocalDateTime.now();
     }
 
     public void reject() {

--- a/src/main/java/com/example/demo/domain/Mate.java
+++ b/src/main/java/com/example/demo/domain/Mate.java
@@ -11,6 +11,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,6 +21,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mate", uniqueConstraints = {
+    @UniqueConstraint(
+        name = "uk_mate_requester_receiver",
+        columnNames = {"requester_id", "receiver_id"}
+    )
+})
 public class Mate extends BaseEntity {
 
     @Id

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -23,10 +23,12 @@ public interface MateRepository extends Repository<Mate, Long> {
     List<Mate> findMates(@Param("id") Long userId, @Param("status") MateStatus mateStatus);
 
     @Query("""
-        SELECT COUNT(m) > 0 FROM Mate m
-        WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id)
-           OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id))
-          AND m.status IN ('PENDING', 'ACCEPTED')
+        SELECT EXISTS(
+            SELECT 1 FROM Mate m
+            WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id)
+                OR (m.requester.id = :user2Id AND m.receiver.id = :user1I))
+                AND m.status IN ('PENDING', 'ACCEPTED')
+        )
         """)
     boolean existsMateBetween(@Param("user1Id") Long user1Id, @Param("user2Id") Long user2Id);
 

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -26,7 +26,7 @@ public interface MateRepository extends Repository<Mate, Long> {
         SELECT EXISTS(
             SELECT 1 FROM Mate m
             WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id)
-                OR (m.requester.id = :user2Id AND m.receiver.id = :user1I))
+                OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id))
                 AND m.status IN ('PENDING', 'ACCEPTED')
         )
         """)
@@ -48,4 +48,6 @@ public interface MateRepository extends Repository<Mate, Long> {
         WHERE m.receiver.id = :userId AND m.status = 'PENDING'
         """)
     List<Mate> findAllPendingByReceiverId(@Param("userId") Long userId);
+
+    void delete(Mate mate);
 }

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -14,26 +14,36 @@ public interface MateRepository extends Repository<Mate, Long> {
     Optional<Mate> findById(Long id);
 
     @Query("""
-        select m from Mate m join fetch m.requester join fetch m.receiver
-             where (m.requester.id = :id or m.receiver.id = :id) and m.status = :status
+        SELECT m FROM Mate m 
+        JOIN FETCH m.requester 
+        JOIN FETCH m.receiver
+        WHERE (m.requester.id = :id OR m.receiver.id = :id) 
+          AND m.status = :status
         """)
     List<Mate> findMates(@Param("id") Long userId, @Param("status") MateStatus mateStatus);
 
-    @Query("SELECT COUNT(m) > 0 FROM Mate m " +
-        "WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id) " +
-        "OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id)) " +
-        "AND m.status IN ('PENDING', 'ACCEPTED')")
+    @Query("""
+        SELECT COUNT(m) > 0 FROM Mate m
+        WHERE ((m.requester.id = :user1Id AND m.receiver.id = :user2Id)
+           OR (m.requester.id = :user2Id AND m.receiver.id = :user1Id))
+          AND m.status IN ('PENDING', 'ACCEPTED')
+        """)
     boolean existsMateBetween(@Param("user1Id") Long user1Id, @Param("user2Id") Long user2Id);
 
-    @Query("SELECT new com.example.demo.domain.MateWithFriend(m, f) " +
-        "FROM Mate m " +
-        "JOIN User f ON (m.requester.id = :userId AND f.id = m.receiver.id) " +
-        "            OR (m.receiver.id = :userId AND f.id = m.requester.id) " +
-        "WHERE m.status = 'ACCEPTED' " +
-        "AND (m.requester.id = :userId OR m.receiver.id = :userId)")
+    @Query("""
+        SELECT new com.example.demo.domain.MateWithFriend(m, f)
+        FROM Mate m
+        JOIN User f ON (m.requester.id = :userId AND f.id = m.receiver.id)
+                    OR (m.receiver.id = :userId AND f.id = m.requester.id)
+        WHERE m.status = 'ACCEPTED'
+          AND (m.requester.id = :userId OR m.receiver.id = :userId)
+        """)
     List<MateWithFriend> findAllAcceptedWithFriend(@Param("userId") Long userId);
 
-    @Query("SELECT m FROM Mate m JOIN FETCH m.requester " +
-        "WHERE m.receiver.id = :userId AND m.status = 'PENDING'")
+    @Query("""
+        SELECT m FROM Mate m
+        JOIN FETCH m.requester
+        WHERE m.receiver.id = :userId AND m.status = 'PENDING'
+        """)
     List<Mate> findAllPendingByReceiverId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/demo/domain/MateRepository.java
+++ b/src/main/java/com/example/demo/domain/MateRepository.java
@@ -38,7 +38,6 @@ public interface MateRepository extends Repository<Mate, Long> {
         JOIN User f ON (m.requester.id = :userId AND f.id = m.receiver.id)
                     OR (m.receiver.id = :userId AND f.id = m.requester.id)
         WHERE m.status = 'ACCEPTED'
-          AND (m.requester.id = :userId OR m.receiver.id = :userId)
         """)
     List<MateWithFriend> findAllAcceptedWithFriend(@Param("userId") Long userId);
 

--- a/src/test/java/com/example/demo/application/MateServiceTest.java
+++ b/src/test/java/com/example/demo/application/MateServiceTest.java
@@ -291,7 +291,7 @@ class MateServiceTest extends AbstractIntegrationTest {
             // then
             Mate mate = mateRepository.findById(mateId).orElseThrow();
             assertThat(mate.getStatus()).isEqualTo(MateStatus.ACCEPTED);
-            assertThat(mate.getAcceptedAt()).isNotNull();
+            assertThat(mate.getModifiedAt()).isNotNull();
         }
 
         @Test

--- a/src/test/java/com/example/demo/application/MateServiceTest.java
+++ b/src/test/java/com/example/demo/application/MateServiceTest.java
@@ -295,7 +295,7 @@ class MateServiceTest extends AbstractIntegrationTest {
         }
 
         @Test
-        void 친구_요청을_거절하면_REJECTED_상태가_된다() {
+        void 친구_요청을_거절하면_삭제된다() {
             // given
             User requester = givenSavedUser(userRepository, new Nickname("요청자"), new InvitationCode("RRRRRR"));
             User receiver = givenSavedUser(userRepository, new Nickname("수신자"), new InvitationCode("EEEEEE"));
@@ -304,9 +304,25 @@ class MateServiceTest extends AbstractIntegrationTest {
             // when
             sut.updateMateStatus(mateId, receiver.getId(), MateStatus.REJECTED);
 
-            // then
-            Mate mate = mateRepository.findById(mateId).orElseThrow();
-            assertThat(mate.getStatus()).isEqualTo(MateStatus.REJECTED);
+            // then: 거절된 요청은 삭제되어 찾을 수 없음
+            assertThat(mateRepository.findById(mateId)).isEmpty();
+        }
+
+        @Test
+        void 거절된_요청은_다시_보낼_수_있다() {
+            // given
+            User requester = givenSavedUser(userRepository, new Nickname("요청자"), new InvitationCode("RRRRRR"));
+            User receiver = givenSavedUser(userRepository, new Nickname("수신자"), new InvitationCode("EEEEEE"));
+            Long firstMateId = sut.requestMate(requester.getId(), "EEEEEE");
+            sut.updateMateStatus(firstMateId, receiver.getId(), MateStatus.REJECTED);
+
+            // when: 다시 요청
+            Long secondMateId = sut.requestMate(requester.getId(), "EEEEEE");
+
+            // then: 새로운 요청이 생성됨
+            assertThat(secondMateId).isNotNull().isNotEqualTo(firstMateId);
+            Mate newMate = mateRepository.findById(secondMateId).orElseThrow();
+            assertThat(newMate.getStatus()).isEqualTo(MateStatus.PENDING);
         }
 
         @Test

--- a/src/test/java/com/example/demo/domain/MateTest.java
+++ b/src/test/java/com/example/demo/domain/MateTest.java
@@ -32,7 +32,6 @@ class MateTest {
             assertThat(mate.getRequester()).isEqualTo(requester);
             assertThat(mate.getReceiver()).isEqualTo(receiver);
             assertThat(mate.getStatus()).isEqualTo(MateStatus.PENDING);
-            assertThat(mate.getAcceptedAt()).isNull();
         }
 
         @Test
@@ -68,7 +67,6 @@ class MateTest {
             mate.accept();
 
             assertThat(mate.getStatus()).isEqualTo(MateStatus.ACCEPTED);
-            assertThat(mate.getAcceptedAt()).isNotNull();
         }
 
         @Test

--- a/src/test/java/com/example/demo/domain/MateTest.java
+++ b/src/test/java/com/example/demo/domain/MateTest.java
@@ -79,46 +79,27 @@ class MateTest {
                 .hasMessage("대기 중인 요청만 수락할 수 있습니다.");
         }
 
-        @Test
-        void REJECTED에서_친구수락_요청시_예외발생() {
-            Mate mate = new Mate(requester, receiver);
-            mate.reject();
-
-            assertThatThrownBy(mate::accept)
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("대기 중인 요청만 수락할 수 있습니다.");
-        }
     }
 
     @Nested
-    @DisplayName("reject 검증")
-    class RejectValidation {
+    @DisplayName("validateIsPending 검증")
+    class ValidateIsPendingValidation {
 
         @Test
-        void 친구거절시_PENDING에서_REJECTED로_변경() {
+        void PENDING_상태에서_예외가_발생하지_않는다() {
             Mate mate = new Mate(requester, receiver);
 
-            mate.reject();
+            mate.validateIsPending();
 
-            assertThat(mate.getStatus()).isEqualTo(MateStatus.REJECTED);
+            assertThat(mate.getStatus()).isEqualTo(MateStatus.PENDING);
         }
 
         @Test
-        void ACCEPTED에서_친구거절_요청시_예외발생() {
+        void ACCEPTED_상태에서_예외가_발생한다() {
             Mate mate = new Mate(requester, receiver);
             mate.accept();
 
-            assertThatThrownBy(mate::reject)
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("대기 중인 요청만 거절할 수 있습니다.");
-        }
-
-        @Test
-        void REJECTED에서_친구거절_요청시_예외발생() {
-            Mate mate = new Mate(requester, receiver);
-            mate.reject();
-
-            assertThatThrownBy(mate::reject)
+            assertThatThrownBy(mate::validateIsPending)
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("대기 중인 요청만 거절할 수 있습니다.");
         }


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 작업 요약을 한 줄로 적어주세요")

## 이슈
- Close #74 

## 요약
- Mate 도메인의 친구 요청 동시성 문제 해결 및 거절 후 재요청 불가 이슈 수정                                                            
- `acceptedAt` 필드 제거 후 `modifiedAt`으로 대체
- `existsMateBetween` 쿼리 성능 최적화 (COUNT → EXISTS)
- `findAllAcceptedWithFriend` 쿼리 내 중복 조건 제거
- 친구 요청 시 본인 확인 로직 리팩토링
- MateRepository 쿼리문을 text block으로 수정

## 설계 의도 / 결정 사항
- 동일한 유저 간의 중복 Mate 생성을 방지하기 위해 (requester_id, receiver_id) 복합 유니크 제약 조건을 추가했습니다. 
    - 기존에는 친구요청 거절 시 MateStatus를 REJECTED로 변경했으나, 이 경우 유니크 제약으로 인해 추후 재요청이 불가능해지는 문제가 있었습니다. 이 문제를 해결하기 위해 거절 시 해당 엔티티를 DB에서 hard delete하는 방식을 선택했습니다.
    - 이 방식을 통해 별도의 복잡한 동시성 제어 로직 없이도 DB 레벨에서 중복 요청을 차단할 수 있다고 판단했습니다. 
    이 로직에 대해 기석님은 의견이 궁금합니다!


## 리뷰 요청 / 고민 포인트
- [설계 의도 / 결정 사항] 부분에 작성한 것 말고는 딱히 없습니다 :)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 거절된 매칭 요청 후 사용자가 동일 대상에게 새 요청을 다시 보낼 수 있습니다.

* **버그 수정**
  * 동일 사용자 간 중복 요청을 방지하는 데이터베이스 수준 제약 추가.
  * 동시 중복 요청 발생 시 오류 처리 개선으로 중복 삽입 상황 안정화.
  * 거절 처리 변경: 거절 시 요청이 제거되도록 수정되어 재요청 흐름이 개선됨.

* **테스트**
  * 수용/거절 관련 테스트를 실제 동작(삭제 및 수정 시간 등)에 맞춰 갱신.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->