### PR TITLE
Verdict 도메인 N+1 문제 해결 및 리팩터링

### DIFF
--- a/src/main/java/com/example/demo/domain/User.java
+++ b/src/main/java/com/example/demo/domain/User.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -79,6 +80,6 @@ public class User extends BaseEntity {
 
     @Override
     public int hashCode() {
-        return getClass().hashCode();
+        return Objects.hash(getId());
     }
 }

--- a/src/main/java/com/example/demo/domain/Verdict.java
+++ b/src/main/java/com/example/demo/domain/Verdict.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Verdict {
+public class Verdict extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/demo/domain/VerdictRepository.java
+++ b/src/main/java/com/example/demo/domain/VerdictRepository.java
@@ -15,12 +15,17 @@ public interface VerdictRepository extends Repository<Verdict, Long> {
     List<Verdict> findAllByLedgerEntry_Id(Long ledgerEntryId);
 
     @Query("""
-        select v from Verdict v where v.ledgerEntry.user.id = :userId
+        select v FROM Verdict v 
+        JOIN FETCH v.ledgerEntry 
+        WHERE v.ledgerEntry.user.id = :userId
         """)
     List<Verdict> findMyVerdicts(@Param("userId") Long userId);
 
     @Query("""
-        select v from Verdict v where v.juror.id = :userId
+        SELECT v FROM Verdict v 
+        JOIN FETCH v.juror
+        JOIN FETCH v.ledgerEntry 
+        WHERE v.juror.id = :userId
         """)
     List<Verdict> findJurorVerdicts(@Param("userId") Long userId);
 

--- a/src/main/java/com/example/demo/domain/VerdictRepository.java
+++ b/src/main/java/com/example/demo/domain/VerdictRepository.java
@@ -16,7 +16,8 @@ public interface VerdictRepository extends Repository<Verdict, Long> {
 
     @Query("""
         select v FROM Verdict v 
-        JOIN FETCH v.ledgerEntry 
+        JOIN FETCH v.ledgerEntry
+        JOIN FETCH v.juror
         WHERE v.ledgerEntry.user.id = :userId
         """)
     List<Verdict> findMyVerdicts(@Param("userId") Long userId);
@@ -24,7 +25,8 @@ public interface VerdictRepository extends Repository<Verdict, Long> {
     @Query("""
         SELECT v FROM Verdict v 
         JOIN FETCH v.juror
-        JOIN FETCH v.ledgerEntry 
+        JOIN FETCH v.ledgerEntry le
+        JOIN FETCH le.user
         WHERE v.juror.id = :userId
         """)
     List<Verdict> findJurorVerdicts(@Param("userId") Long userId);

--- a/src/main/java/com/example/demo/infrastructure/controller/VerdictController.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/VerdictController.java
@@ -10,6 +10,7 @@ import com.example.demo.infrastructure.controller.dto.MyVerdictsWebResponse;
 import com.example.demo.infrastructure.controller.dto.RequestJudgeWebRequest;
 import com.example.demo.infrastructure.controller.dto.VerdictJudgeWebRequest;
 import com.example.demo.infrastructure.interceptor.UserId;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,13 +27,13 @@ public class VerdictController {
     private final VerdictService verdictService;
 
     @PostMapping("/verdicts")
-    public ResponseEntity<Void> requestJudge(@RequestBody RequestJudgeWebRequest request, @UserId Long userId) {
+    public ResponseEntity<Void> requestJudge(@Valid @RequestBody RequestJudgeWebRequest request, @UserId Long userId) {
         verdictService.requestVerdict(request.ledgerEntryId(), userId);
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/verdicts/{id}")
-    public ResponseEntity<JurorVerdictWebResponse> judge(@RequestBody VerdictJudgeWebRequest request,
+    public ResponseEntity<JurorVerdictWebResponse> judge(@Valid @RequestBody VerdictJudgeWebRequest request,
                                       @PathVariable("id") Long verdictId,
                                       @UserId Long jurorId
     ) {

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/JurorVerdictWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/JurorVerdictWebResponse.java
@@ -3,9 +3,6 @@ package com.example.demo.infrastructure.controller.dto;
 import com.example.demo.application.dto.JurorVerdict;
 import com.example.demo.application.dto.LedgerEntryInfo;
 import com.example.demo.application.dto.UserInfo;
-import com.example.demo.domain.LedgerEntry;
-import com.example.demo.domain.User;
-import com.example.demo.domain.Verdict;
 import com.example.demo.domain.VerdictType;
 
 public record JurorVerdictWebResponse(

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/JurorVerdictsWebResponse.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/JurorVerdictsWebResponse.java
@@ -1,8 +1,6 @@
 package com.example.demo.infrastructure.controller.dto;
 
-import com.example.demo.application.dto.JurorVerdict;
 import com.example.demo.application.dto.JurorVerdicts;
-import com.example.demo.domain.Verdict;
 import java.util.List;
 
 public record JurorVerdictsWebResponse(

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/RequestJudgeWebRequest.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/RequestJudgeWebRequest.java
@@ -1,6 +1,9 @@
 package com.example.demo.infrastructure.controller.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record RequestJudgeWebRequest(
+    @NotBlank
     Long ledgerEntryId
 ) {
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/RequestJudgeWebRequest.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/RequestJudgeWebRequest.java
@@ -1,9 +1,9 @@
 package com.example.demo.infrastructure.controller.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record RequestJudgeWebRequest(
-    @NotBlank
+    @NotNull
     Long ledgerEntryId
 ) {
 }

--- a/src/main/java/com/example/demo/infrastructure/controller/dto/VerdictJudgeWebRequest.java
+++ b/src/main/java/com/example/demo/infrastructure/controller/dto/VerdictJudgeWebRequest.java
@@ -1,8 +1,10 @@
 package com.example.demo.infrastructure.controller.dto;
 
 import com.example.demo.domain.VerdictType;
+import jakarta.validation.constraints.NotNull;
 
 public record VerdictJudgeWebRequest(
+    @NotNull(message = "심판 유형(type)은 필수입니다.")
     VerdictType verdictType
 ) {
 }


### PR DESCRIPTION
[//]: # (title: "[Closes #] feat: 작업 요약을 한 줄로 적어주세요")

## 이슈
- Close #65 

## 요약
- n+1 문제를 해결합니다.
- 이외에도 소소한 수정들이 있습니다.
  - User hashCode를 id 기반으로 생성하도록 변경
  - Valid 어노테이션 추가

- 그리고 제안해주신 `saveAll()` 메서드의 경우 JPA의 `Repository` 인터페이스를 상속하고 있으면, saveAll을 자동으로 생성해주지 않더라고요!
- 또한, saveAll 내부 구조가 결국 여러번 save를 호출하는 형태라 크게 다르지 않을 거 같다고 판단해서 그대로 두었습니다.
- 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 출시 노트

* **버그 수정**
  * 객체 비교/해시 일치로 컬렉션 처리 안정성 향상

* **새로운 기능 / 유효성 검사**
  * 심판 관련 요청의 입력 검증 적용으로 잘못된 요청 차단
  * 특정 필수 필드에 대한 명확한 오류 메시지 추가

* **성능 개선**
  * 관련 데이터 조회 시 연관 항목을 함께 불러와 응답 지연 감소
<!-- end of auto-generated comment: release notes by coderabbit.ai -->